### PR TITLE
Implement pretty renderer

### DIFF
--- a/changelog/sources/markdown/pretty/pretty.go
+++ b/changelog/sources/markdown/pretty/pretty.go
@@ -1,7 +1,9 @@
 package pretty
 
 import (
+	"fmt"
 	"io"
+	"strings"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/ast"
@@ -10,45 +12,55 @@ import (
 // Renderer is a markdown.Renderer wrapper that adds empty newlines after and before certain elements.
 type Renderer struct {
 	markdown.Renderer
+	writtenNewline bool
 }
 
 // New returns a new Renderer.
 // TODO: It would be great to be able to configure this to have customizable "before" and "after" spacing.
-func New(inner markdown.Renderer) Renderer {
-	return Renderer{
-		Renderer: inner,
+func New(inner markdown.Renderer) *Renderer {
+	return &Renderer{
+		Renderer:       inner,
+		writtenNewline: true, // Initialized to true to prevent a leading newline to be written before the first header.
 	}
 }
 
 // RenderNode intercepts the inner renderer's RenderNode, implementing the newline logic.
-func (p Renderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.WalkStatus {
+func (p *Renderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.WalkStatus {
 	switch {
-	case entering && p.spaceBefore(node):
-		fallthrough
+	case entering && p.spaceBefore(node) && !p.writtenNewline:
+		p.newline(w)
 	case !entering && p.spaceAfter(node):
-		_, _ = io.WriteString(w, "\n")
+		p.newline(w)
+	default:
+		p.writtenNewline = false
+	}
+
+	if cb, isCodeBlock := node.(*ast.CodeBlock); isCodeBlock {
+		// Hack: The default renderer just does not handle well code blocks.
+		fmt.Fprintf(w, "```\n%s\n```\n", strings.TrimSpace(string(cb.Literal)))
+		return ast.GoToNext
 	}
 
 	return p.Renderer.RenderNode(w, node, entering)
 }
 
 // spaceAfter returns true if an empty newline should be printer after a node.
-func (p Renderer) spaceAfter(node ast.Node) bool {
-	// TODO: This seemed like a great idea at first, but it does not behave as expected if we have a list and a heading
-	// just after it, as it will add a newline for each resulting in two empty lines.
-	// For now, we will just leave with paragraphs cuddled with lists.
-
-	//nolint:gocritic // This is commented-out code and therefore it does not need space before text.
-	//switch node.(type) {
-	//case *ast.List:
-	//	return true
-	//}
+func (p *Renderer) spaceAfter(node ast.Node) bool {
+	switch node.(type) {
+	case *ast.List:
+		return true
+	case *ast.Paragraph:
+		_, isRootParagraph := node.GetParent().(*ast.Document)
+		return isRootParagraph
+	case *ast.CodeBlock:
+		return true
+	}
 
 	return false
 }
 
 // spaceBefore returns true if an empty newline should be printer before a node.
-func (p Renderer) spaceBefore(node ast.Node) bool {
+func (p *Renderer) spaceBefore(node ast.Node) bool {
 	//nolint:gocritic // Written as a switch-case rather than if to allow adding more cases easily.
 	switch h := node.(type) {
 	case *ast.Heading:
@@ -56,4 +68,9 @@ func (p Renderer) spaceBefore(node ast.Node) bool {
 	}
 
 	return false
+}
+
+func (p *Renderer) newline(w io.Writer) {
+	p.writtenNewline = true
+	_, _ = io.WriteString(w, "\n")
 }

--- a/changelog/sources/markdown/pretty/pretty_test.go
+++ b/changelog/sources/markdown/pretty/pretty_test.go
@@ -20,11 +20,15 @@ As you can see
 ## Incredibly unreadable
 ## Dontyathink
 - Heck yes
+- Here's another
 
 I think so
+` + "```" + `
+Here, have a code block
+` + "```" + `
 `
 
-	// Lack of space between list and paragraph is, unfortunately, expected.
+	// Lack of newline between list and paragraph is, unfortunately, expected.
 	expected := `# I'm a markdown document
 Here's a pragraph
 
@@ -37,15 +41,21 @@ As you can see
 
 ## Dontyathink
 - Heck yes
+- Here's another
+
 I think so
+
+` + "```" + `
+Here, have a code block
+` + "```" + `
 `
 
 	root := markdown.Parse([]byte(orig), parser.New())
-
 	buf := &strings.Builder{}
 	buf.Write(markdown.Render(root, pretty.New(md.NewRenderer())))
 
-	if diff := cmp.Diff(expected, buf.String()); diff != "" {
+	actual := buf.String()
+	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Fatalf("Output markdown is not as expected:\n%s", diff)
 	}
 }


### PR DESCRIPTION
`pretty.Renderer` is a `markdown.Renderer` that adds spaces after or before some markdown nodes to make the output pretty.