### PR TITLE
Shorten deps flag for rendering and updating

### DIFF
--- a/src/app/render/render.go
+++ b/src/app/render/render.go
@@ -17,6 +17,7 @@ const (
 	markdownPathFlag = "markdown"
 	versionFlag      = "version"
 	dateFlag         = "date"
+	shortenDepsFlag  = "shorten_deps"
 )
 
 // Cmd is the cli.Command object for the is-held command.
@@ -47,6 +48,12 @@ var Cmd = &cli.Command{
 			Value:  cli.NewTimestamp(time.Now()),
 			Layout: "2006-01-02",
 		},
+		&cli.BoolFlag{
+			Name:    shortenDepsFlag,
+			EnvVars: common.EnvFor(shortenDepsFlag),
+			Usage:   "If set, dependencies with full-route names will be shortened to the last segment.",
+			Value:   false,
+		},
 	},
 	Action: Render,
 }
@@ -72,7 +79,8 @@ func Render(cCtx *cli.Context) error {
 		return fmt.Errorf("creating destination file at %q: %w", mdPath, err)
 	}
 
-	rnd := renderer.New(ch)
+	shortenDeps := cCtx.Bool(shortenDepsFlag)
+	rnd := renderer.New(ch, renderer.ShortenDeps(shortenDeps))
 
 	if t := cCtx.Timestamp(dateFlag); t != nil {
 		tv := *t

--- a/src/app/render/render_test.go
+++ b/src/app/render/render_test.go
@@ -120,6 +120,57 @@ This is a release note
 - Support has been removed
 			`),
 		},
+		{
+			name: "Changelog_With_Long_Dependency_Without_Shorten_deps",
+			yaml: strings.TrimSpace(`
+notes: |-
+    ### Important announcement (note)
+
+    This is a release note
+dependencies:
+- name: foobar
+  from: 0.0.1
+  to: 0.1.0
+- name: github.com/golangci/golangci-lint
+  from: 0.2.5
+  to: 0.3.0
+			`),
+			expected: strings.TrimSpace(`
+### Important announcement (note)
+
+This is a release note
+
+### ⛓️ Dependencies
+- Upgraded foobar from 0.0.1 to 0.1.0
+- Upgraded github.com/golangci/golangci-lint from 0.2.5 to 0.3.0
+			`),
+		},
+		{
+			name: "Changelog_With_Long_Dependency_Shorten_deps",
+			args: "-shorten_deps=true",
+			yaml: strings.TrimSpace(`
+notes: |-
+    ### Important announcement (note)
+
+    This is a release note
+dependencies:
+- name: foobar
+  from: 0.0.1
+  to: 0.1.0
+- name: github.com/golangci/golangci-lint
+  from: 0.2.5
+  to: 0.3.0
+			`),
+			expected: strings.TrimSpace(`
+### Important announcement (note)
+
+This is a release note
+
+### ⛓️ Dependencies
+- Upgraded foobar from 0.0.1 to 0.1.0
+- Upgraded golangci-lint from 0.2.5 to 0.3.0
+			`),
+		},
 	} {
 		tc := tc
 		//nolint:paralleltest // urfave/cli cannot be tested concurrently.

--- a/src/app/update/update.go
+++ b/src/app/update/update.go
@@ -17,6 +17,7 @@ const (
 	markdownPathFlag = "markdown"
 	versionFlag      = "version"
 	dateFlag         = "date"
+	shortenDepsFlag  = "shorten_deps"
 )
 
 // Cmd is the cli.Command object for the update-changelog command.
@@ -47,6 +48,12 @@ var Cmd = &cli.Command{
 				"If empty it will default to the current time (time.Now()).",
 			Value:  cli.NewTimestamp(time.Now()),
 			Layout: "2006-01-02",
+		},
+		&cli.BoolFlag{
+			Name:    shortenDepsFlag,
+			EnvVars: common.EnvFor(shortenDepsFlag),
+			Usage:   "If set, dependencies with full-route names will be shortened to the last segment.",
+			Value:   false,
 		},
 	},
 	Action: Update,
@@ -85,7 +92,8 @@ func Update(cCtx *cli.Context) error {
 		return fmt.Errorf("parsing version: %w", err)
 	}
 
-	mrg := merger.New(ch, version)
+	shortenDeps := cCtx.Bool(shortenDepsFlag)
+	mrg := merger.New(ch, version, merger.ShortenDeps(shortenDeps))
 	if t := cCtx.Timestamp(dateFlag); t != nil {
 		tv := *t
 		mrg.ReleasedOn = func() time.Time {

--- a/src/app/update/update_test.go
+++ b/src/app/update/update_test.go
@@ -83,6 +83,88 @@ This is a release note
 			`) + "\n",
 		},
 		{
+			name: "Changelog_Now_Long_Dependency_Without_Shorten_Deps",
+			args: "-version v1.2.4",
+			yaml: strings.TrimSpace(`
+notes: |-
+    ### Important announcement (note)
+
+    This is a release note
+dependencies:
+- name: github.com/golangci/golangci-lint
+  from: 0.0.1
+  to: 0.1.0
+			`),
+			existing: strings.TrimSpace(`
+# Changelog
+This is based on blah blah blah
+
+## v1.2.3 - 20YY-DD-MM
+
+### Enhancements
+- This is in the past and should be preserved
+			`) + "\n",
+			expected: strings.TrimSpace(`
+# Changelog
+This is based on blah blah blah
+
+## v1.2.4 - {NOW}
+
+### Important announcement (note)
+
+This is a release note
+
+### ⛓️ Dependencies
+- Upgraded github.com/golangci/golangci-lint from 0.0.1 to 0.1.0
+
+## v1.2.3 - 20YY-DD-MM
+
+### Enhancements
+- This is in the past and should be preserved
+			`) + "\n",
+		},
+		{
+			name: "Changelog_Now_Long_Dependency_With_Shorten_Deps",
+			args: "-version v1.2.4 -shorten_deps=true",
+			yaml: strings.TrimSpace(`
+notes: |-
+    ### Important announcement (note)
+
+    This is a release note
+dependencies:
+- name: github.com/golangci/golangci-lint
+  from: 0.0.1
+  to: 0.1.0
+			`),
+			existing: strings.TrimSpace(`
+# Changelog
+This is based on blah blah blah
+
+## v1.2.3 - 20YY-DD-MM
+
+### Enhancements
+- This is in the past and should be preserved
+			`) + "\n",
+			expected: strings.TrimSpace(`
+# Changelog
+This is based on blah blah blah
+
+## v1.2.4 - {NOW}
+
+### Important announcement (note)
+
+This is a release note
+
+### ⛓️ Dependencies
+- Upgraded golangci-lint from 0.0.1 to 0.1.0
+
+## v1.2.3 - 20YY-DD-MM
+
+### Enhancements
+- This is in the past and should be preserved
+			`) + "\n",
+		},
+		{
 			name: "Full_Changelog_With_Date",
 			args: "-version v1.2.4 -date 1993-09-21",
 			yaml: strings.TrimSpace(`


### PR DESCRIPTION
- Add flag to shorten dependency names to the last segment in the path.