### PR TITLE
Make generate command exit with error if generated changelog is empty

### DIFF
--- a/.github/workflows/self_test.yaml
+++ b/.github/workflows/self_test.yaml
@@ -109,6 +109,50 @@ jobs:
             exit 2
           fi
 
+  generate-changelog-empty:
+    name: generate-changelog action empty changelog
+    runs-on: ubuntu-latest
+    env:
+      MOCK_REPO: ./mock_repo
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure test repo
+        id: repo
+        shell: bash
+        run: |
+          mkdir $MOCK_REPO
+          cd $MOCK_REPO
+
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+
+          git init
+          for i in 1 2 3; do
+            touch file$i
+            git add file$i
+            git commit -m commit_$i
+          done
+
+          cat > CHANGELOG.md <<EOF
+          # Changelog
+          The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+          and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+          ## Unreleased
+          EOF
+      - uses: ./generate-changelog
+        id: generate-changelog
+        with:
+          yaml: ${{ env.MOCK_REPO }}/changelog.yaml
+          markdown: ${{ env.MOCK_REPO }}/CHANGELOG.md
+          git-root: ${{ env.MOCK_REPO }}
+          exit-code: 0
+      - run: |
+          if [[ "${{ steps.generate-changelog.outputs.empty-changelog }}" != "true" ]]; then
+            echo "empty-changelog should have returned true" >&2
+            exit 1
+          fi
+
   next-version:
     name: next-version action
     runs-on: ubuntu-latest

--- a/generate-changelog/action.yml
+++ b/generate-changelog/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: Exclude commits whose changes only impact files in specified dirs relative to repository root
     required: false
     default: ""
+  exit-code:
+    description: Exit code if changelog is empty
+    required: false
+    default: "1"
 runs:
   using: docker
   image: ../Dockerfile
@@ -52,3 +56,5 @@ runs:
     - ${{ inputs.included-dirs }}
     - --excluded-dirs
     - ${{ inputs.excluded-dirs }}
+    - --exit-code
+    - ${{ inputs.exit-code }}

--- a/src/changelog/changelog.go
+++ b/src/changelog/changelog.go
@@ -44,6 +44,11 @@ func (c *Changelog) Merge(other *Changelog) {
 	c.Dependencies = append(c.Dependencies, other.Dependencies...)
 }
 
+// Empty returns true if this changelog contains no data.
+func (c *Changelog) Empty() bool {
+	return !c.Held && c.Notes == "" && len(c.Changes) == 0 && len(c.Dependencies) == 0
+}
+
 // Entry is a representation of a change that has been made in the code.
 type Entry struct {
 	// Type holds which bump this change was: A bug fix, a new feature, etc. See EntryType.

--- a/src/changelog/changelog_test.go
+++ b/src/changelog/changelog_test.go
@@ -93,6 +93,48 @@ func TestChangelog_Merge(t *testing.T) {
 	}
 }
 
+func TestChangelog_Empty(t *testing.T) {
+	t.Parallel()
+
+	const numChangelogFields = 4
+
+	for _, tc := range []struct {
+		name      string
+		changelog *changelog.Changelog
+		expected  bool
+	}{
+		{
+			name: "Changelog_Is_Not_Empty",
+			changelog: &changelog.Changelog{
+				Changes: []changelog.Entry{
+					{Message: "Change one", Type: changelog.TypeBugfix},
+				},
+				Dependencies: []changelog.Dependency{
+					{Name: "Dependency 1"},
+					{Name: "Dependency 2"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:      "Changelog_Is_Empty",
+			changelog: &changelog.Changelog{},
+			expected:  true,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.expected != tc.changelog.Empty() {
+				t.Fatalf("Expected %t got %t", tc.expected, tc.changelog.Empty())
+			}
+			if len(reflect.VisibleFields(reflect.TypeOf(changelog.Changelog{}))) != numChangelogFields {
+				t.Fatal("Inconsistency detected, the number of checked fields in Empty() function is lower than Changelog's fields")
+			}
+		})
+	}
+}
+
 func TestChangelog_Merge_Does_Duplicate_Entries(t *testing.T) {
 	// Current implementation does not deduplicate entries. This test attest this as intended behavior.
 	t.Parallel()


### PR DESCRIPTION
- Generate empty changelog returns an exit-code and gha output