### PR TITLE
Compute also old valid version with brackets

### DIFF
--- a/src/app/update/update_test.go
+++ b/src/app/update/update_test.go
@@ -139,6 +139,53 @@ This is a release note
 - This is in the past and should be preserved
 			`) + "\n",
 		},
+		{
+			name: "Changelog_Old_Version_With_Brackets",
+			args: "-version v1.2.4 -date 1993-09-21",
+			yaml: strings.TrimSpace(`
+notes: |-
+    ### Important announcement (note)
+
+    This is a release note
+changes:
+- type: breaking
+  message: Support has been removed
+dependencies:
+- name: foobar
+  from: 0.0.1
+  to: 0.1.0
+			`),
+			existing: strings.TrimSpace(`
+# Changelog
+This is based on blah blah blah
+
+## [1.2.3] - 2022-09-20
+
+### Added
+- This is in the past and should be preserved
+			`) + "\n",
+			expected: strings.TrimSpace(`
+# Changelog
+This is based on blah blah blah
+
+## v1.2.4 - 1993-09-21
+
+### Important announcement (note)
+
+This is a release note
+
+### ⚠️️ Breaking changes ⚠️
+- Support has been removed
+
+### ⛓️ Dependencies
+- Upgraded foobar from 0.0.1 to 0.1.0
+
+## [1.2.3] - 2022-09-20
+
+### Added
+- This is in the past and should be preserved
+			`) + "\n",
+		},
 	} {
 		tc := tc
 		//nolint:paralleltest // urfave/cli cannot be tested concurrently.

--- a/src/changelog/sources/markdown/merger/merger.go
+++ b/src/changelog/sources/markdown/merger/merger.go
@@ -43,7 +43,7 @@ func New(ch *changelog.Changelog, newVersion *semver.Version) Merger {
 var (
 	unreleasedHeader = regexp.MustCompile(`(?i)^##\s*unreleased`)
 	heldHeader       = regexp.MustCompile(`(?i)^##\s*held`)
-	l2Header         = regexp.MustCompile(`^##\s*\w`)
+	l2Header         = regexp.MustCompile(`^##\s*[^#\s]`)
 )
 
 // Merge uses the configured changelog and version to read the current, full changelog in Markdown format from

--- a/src/changelog/sources/markdown/merger/merger_test.go
+++ b/src/changelog/sources/markdown/merger/merger_test.go
@@ -229,6 +229,33 @@ This is based on blah blah blah
 			`) + "\n",
 		},
 		{
+			name: "Simple_Changelog_With_Brackets",
+			ch:   simpleChangelog,
+			original: strings.TrimSpace(`
+# Changelog
+This is based on blah blah blah
+
+## [v1.2.3] - 20YY-DD-MM
+
+### Enhancements
+- This is in the past and should be preserved
+			`) + "\n",
+			expected: strings.TrimSpace(`
+# Changelog
+This is based on blah blah blah
+
+## v1.2.4 - 1993-09-21
+
+### 🐞 Bug fixes
+- Fixed this
+
+## [v1.2.3] - 20YY-DD-MM
+
+### Enhancements
+- This is in the past and should be preserved
+			`) + "\n",
+		},
+		{
 			// This is an edge case where Merger does not behave extremely well.
 			// Merger cannot easily handle whether before the place where the new section will be inserted, so we took
 			// the decision to assume there will be a space before.


### PR DESCRIPTION
Old valid keepachangelog versions like this one:

````
## [v1.2.3] - 20YY-DD-MM

### Enhancements
- This is in the past and should be preserved
````

Are being removed or not computed.