### PR TITLE
feat(next-tag): making output tag configurable

### DIFF
--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	tagPrefix   = "tag-prefix"
-	currentFlag = "current"
-	nextFlag    = "next"
-	gitRootFlag = "git-root"
+	outputPrefix = "output-prefix"
+	tagPrefix    = "tag-prefix"
+	currentFlag  = "current"
+	nextFlag     = "next"
+	gitRootFlag  = "git-root"
 )
 
 const nextVersionOutput = "next-version"
@@ -41,6 +42,12 @@ Several flags can be specified to limit the set of tags that are scanned, and to
 			EnvVars: common.EnvFor(tagPrefix),
 			Usage:   "Consider only tags matching this prefix for figuring out the current version.",
 			Value:   "",
+		},
+		&cli.StringFlag{
+			Name:    outputPrefix,
+			EnvVars: common.EnvFor(outputPrefix),
+			Usage:   "Add the following tag when printing the output tag.",
+			Value:   "v",
 		},
 		&cli.StringFlag{
 			Name:    currentFlag,
@@ -117,8 +124,8 @@ func NextVersion(cCtx *cli.Context) error {
 		return fmt.Errorf("bumping source: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(cCtx.App.Writer, "v%s\n", nextStr)
-	gh.SetOutput(nextVersionOutput, fmt.Sprintf("v%s", nextStr))
+	_, _ = fmt.Fprintf(cCtx.App.Writer, "%s%s\n", cCtx.String(outputPrefix), nextStr)
+	gh.SetOutput(nextVersionOutput, fmt.Sprintf("%s%s", cCtx.String(outputPrefix), nextStr))
 
 	return nil
 }

--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -46,7 +46,7 @@ Several flags can be specified to limit the set of tags that are scanned, and to
 		&cli.StringFlag{
 			Name:    outputPrefix,
 			EnvVars: common.EnvFor(outputPrefix),
-			Usage:   "Add the following tag when printing the output tag.",
+			Usage:   "The prefix to prepend when printing the output version.",
 			Value:   "v",
 		},
 		&cli.StringFlag{

--- a/src/app/nextversion/nextversion_test.go
+++ b/src/app/nextversion/nextversion_test.go
@@ -225,6 +225,26 @@ changes:
   message: New feature has been added
 			`),
 		},
+		{
+			name:     "Set_Output_Prefix",
+			expected: "prefix-5.1.0",
+			args:     "--tag-prefix chart- --output-prefix=prefix-",
+			yaml: strings.TrimSpace(`
+changes:
+- type: enhancement
+  message: New feature has been added
+			`),
+		},
+		{
+			name:     "Set_No_Prefix",
+			expected: "5.1.0",
+			args:     "--tag-prefix chart- --output-prefix=",
+			yaml: strings.TrimSpace(`
+changes:
+- type: enhancement
+  message: New feature has been added
+			`),
+		},
 	} {
 		tc := tc
 		//nolint:paralleltest // urfave/cli cannot be tested concurrently.


### PR DESCRIPTION
In some scenarios, you do not want a prefix in the output or you want a different one.

For example, releasing a chart you do not need the tool to return a value such as "v1.y.z" but you would like something like "chart-x-y-z". Moreover, when writing docs you might need no prefix at all "x.y.z"

The old behaviour is kept thanks to the default `v`