### PR TITLE
[NR-57250] fix(tags): ignoring tags from different branches

### DIFF
--- a/src/app/generate/generate.go
+++ b/src/app/generate/generate.go
@@ -191,13 +191,15 @@ func addDepSource(cCtx *cli.Context, sources []changelog.Source, includedDirs, e
 }
 
 func tagVersionGetter(cCtx *cli.Context) (*git.TagsSource, error) {
-	var tagOpts []git.TagOptionFunc
+	workDir := cCtx.String(gitRootFlag)
+	commitsGetter := git.NewRepoCommitsGetter(workDir)
+
+	tagOpts := []git.TagOptionFunc{git.TagsMatchingCommits(commitsGetter)}
 	if matching := cCtx.String(tagPrefixFlag); matching != "" {
-		tagOpts = append(tagOpts, git.TagsMatching("^"+matching))
+		tagOpts = append(tagOpts, git.TagsMatchingRegex("^"+matching))
 	}
 
-	workDir := cCtx.String(gitRootFlag)
-	src, err := git.NewRepoTagsGetter(workDir, git.NewRepoCommitsGetter(workDir), tagOpts...)
+	src, err := git.NewRepoTagsGetter(workDir, tagOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating source for git tags: %w", err)
 	}

--- a/src/app/generate/generate.go
+++ b/src/app/generate/generate.go
@@ -196,7 +196,8 @@ func tagVersionGetter(cCtx *cli.Context) (*git.TagsSource, error) {
 		tagOpts = append(tagOpts, git.TagsMatching("^"+matching))
 	}
 
-	src, err := git.NewRepoTagsGetter(cCtx.String(gitRootFlag), tagOpts...)
+	workDir := cCtx.String(gitRootFlag)
+	src, err := git.NewRepoTagsGetter(workDir, git.NewRepoCommitsGetter(workDir), tagOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating source for git tags: %w", err)
 	}

--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -150,13 +150,15 @@ func source(cCtx *cli.Context) (version.Source, error) {
 		return version.Static(override), nil
 	}
 
-	var tagOpts []git.TagOptionFunc
+	workDir := cCtx.String(gitRootFlag)
+	getter := git.NewRepoCommitsGetter(workDir)
+
+	tagOpts := []git.TagOptionFunc{git.TagsMatchingCommits(getter)}
 	if prefix := cCtx.String(tagPrefix); prefix != "" {
-		tagOpts = append(tagOpts, git.TagsMatching("^"+prefix))
+		tagOpts = append(tagOpts, git.TagsMatchingRegex("^"+prefix))
 	}
 
-	workDir := cCtx.String(gitRootFlag)
-	tg, err := git.NewRepoTagsGetter(workDir, git.NewRepoCommitsGetter(workDir), tagOpts...)
+	tg, err := git.NewRepoTagsGetter(workDir, tagOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("building repo tags lister: %w", err)
 	}

--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -155,7 +155,8 @@ func source(cCtx *cli.Context) (version.Source, error) {
 		tagOpts = append(tagOpts, git.TagsMatching("^"+prefix))
 	}
 
-	tg, err := git.NewRepoTagsGetter(cCtx.String(gitRootFlag), tagOpts...)
+	workDir := cCtx.String(gitRootFlag)
+	tg, err := git.NewRepoTagsGetter(workDir, git.NewRepoCommitsGetter(workDir), tagOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("building repo tags lister: %w", err)
 	}

--- a/src/app/nextversion/nextversion_test.go
+++ b/src/app/nextversion/nextversion_test.go
@@ -21,8 +21,8 @@ func TestNextVersion_Without_Repo(t *testing.T) {
 		globalargs string
 	}{
 		{
-			name:     "Overrides_Next",
-			args:     "-next v0.0.1",
+			name:     "Overrides_Next_And_Current",
+			args:     "-next v0.0.1 -current v1.2.3",
 			expected: "v0.0.1",
 			yaml: strings.TrimSpace(`
 notes: |-
@@ -157,7 +157,8 @@ dependencies:
 		},
 		{
 			name:     "Overrides_Current",
-			expected: "v3.0.0",
+			args:     "--current v0.0.1",
+			expected: "v1.0.0",
 			yaml: strings.TrimSpace(`
 notes: |-
     ### Important announcement (note)

--- a/src/git/commit_filter.go
+++ b/src/git/commit_filter.go
@@ -51,7 +51,7 @@ func NewCommitFilter(commitsGetter CommitsGetter, opts ...CommitFilterOptionFunc
 
 	for _, opt := range opts {
 		if err := opt(cf); err != nil {
-			return nil, fmt.Errorf("commit filter, applyng option: %w", err)
+			return nil, fmt.Errorf("commit filter, applying option: %w", err)
 		}
 	}
 

--- a/src/git/tag.go
+++ b/src/git/tag.go
@@ -39,7 +39,7 @@ func TagsMatchingRegex(regex string) TagOptionFunc {
 	}
 }
 
-// TagsMatchingCommits returns an option that will make the getter to ignore tags that do not match commits.
+// TagsMatchingCommits returns an option that will skip tags that do not point to a commit reachable from HEAD.
 func TagsMatchingCommits(getter CommitsGetter) TagOptionFunc {
 	return func(s *RepoTagsGetter) error {
 		branchCommits, err := getter.Commits(EmptyTreeID)

--- a/src/git/tag.go
+++ b/src/git/tag.go
@@ -108,7 +108,7 @@ func (s *RepoTagsGetter) Tags() ([]Tag, error) {
 }
 
 // getCommitsMap retrieves the list of commits from HEAD and put it in a map in order to
-// filter out all the tags not belonging to the current branch
+// filter out all the tags not belonging to the current branch.
 func getCommitsMap(commitGetter CommitsGetter) (map[string]bool, error) {
 	branchCommits, err := commitGetter.Commits(EmptyTreeID)
 	if err != nil {

--- a/src/git/tag.go
+++ b/src/git/tag.go
@@ -66,7 +66,7 @@ func NewRepoTagsGetter(workDir string, opts ...TagOptionFunc) (*RepoTagsGetter, 
 
 	for _, opt := range opts {
 		if err := opt(s); err != nil {
-			return nil, fmt.Errorf("applyng option: %w", err)
+			return nil, fmt.Errorf("applying option: %w", err)
 		}
 	}
 

--- a/src/git/tag_source_test.go
+++ b/src/git/tag_source_test.go
@@ -35,8 +35,9 @@ func repoWithTags(t *testing.T, tags ...string) string {
 }
 
 func executeCMDs(t *testing.T, cmds []string, dir string) {
-	for _, cmdline := range cmds {
+	t.Helper()
 
+	for _, cmdline := range cmds {
 		cmdparts := strings.Fields(cmdline)
 		//nolint:gosec // This is a test, we trust hardcoded input.
 		cmd := exec.Command(cmdparts[0], cmdparts[1:]...)

--- a/src/git/tag_source_test.go
+++ b/src/git/tag_source_test.go
@@ -131,7 +131,7 @@ func TestTagSource_Versions(t *testing.T) {
 			)
 			executeCMDs(t, tc.cmds, repodir)
 
-			tagsGetter, err := git.NewRepoTagsGetter(repodir, tc.tagOpts...)
+			tagsGetter, err := git.NewRepoTagsGetter(repodir, git.NewRepoCommitsGetter(repodir), tc.tagOpts...)
 			if err != nil {
 				t.Fatalf("Error creating git source: %v", err)
 			}
@@ -203,7 +203,7 @@ func TestRepoTagsSource_LastVersionHash(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			tagsGetter, err := git.NewRepoTagsGetter(repodir, tc.tagOpts...)
+			tagsGetter, err := git.NewRepoTagsGetter(repodir, git.NewRepoCommitsGetter(repodir), tc.tagOpts...)
 			if err != nil {
 				t.Fatalf("Error creating git source: %v", err)
 			}
@@ -223,7 +223,7 @@ func TestRepoTagsSource_LastVersionHash(t *testing.T) {
 func getVersionCommitHash(t *testing.T, repodir, version string, opts ...git.TagOptionFunc) string {
 	t.Helper()
 
-	tagsGetter, err := git.NewRepoTagsGetter(repodir, opts...)
+	tagsGetter, err := git.NewRepoTagsGetter(repodir, git.NewRepoCommitsGetter(repodir), opts...)
 	if err != nil {
 		t.Fatalf("Error creating git source: %v", err)
 	}

--- a/src/git/tag_source_test.go
+++ b/src/git/tag_source_test.go
@@ -66,7 +66,6 @@ func TestTagSource_Versions(t *testing.T) {
 		"helm-chart-1.3.1",
 		"2.0.0-beta",
 	)
-	commitsGetter := git.NewRepoCommitsGetter(repodir)
 
 	for _, tc := range []struct {
 		name          string
@@ -75,9 +74,6 @@ func TestTagSource_Versions(t *testing.T) {
 		expectedTags  []string
 	}{
 		{
-			tagOpts: []git.TagOptionFunc{
-				git.TagsMatchingCommits(commitsGetter),
-			},
 			name: "Default_Settings",
 			expectedTags: []string{
 				"2.0.0-beta",
@@ -89,7 +85,7 @@ func TestTagSource_Versions(t *testing.T) {
 		},
 		{
 			name:    "Matching_Leading_v",
-			tagOpts: []git.TagOptionFunc{git.TagsMatchingRegex("^v"), git.TagsMatchingCommits(commitsGetter)},
+			tagOpts: []git.TagOptionFunc{git.TagsMatchingRegex("^v")},
 			expectedTags: []string{
 				"1.4.0",
 				"1.3.0",
@@ -100,7 +96,6 @@ func TestTagSource_Versions(t *testing.T) {
 			name: "Matching_And_Replacing_Prefix",
 			tagOpts: []git.TagOptionFunc{
 				git.TagsMatchingRegex("^helm-chart-"),
-				git.TagsMatchingCommits(commitsGetter),
 			},
 			tagSourceOpts: []git.TagSourceOptionFunc{
 				git.TagSourceReplacing("helm-chart-", ""),
@@ -199,7 +194,6 @@ func TestRepoTagsSource_LastVersionHash(t *testing.T) {
 		testCommitTag{"helm-chart-1.3.1", []string{"helm-chart-1.3.1"}},
 		testCommitTag{"2.0.0-beta", []string{"2.0.0-beta"}},
 	)
-	commitsGetter := git.NewRepoCommitsGetter(repodir)
 
 	for _, tc := range []struct {
 		name          string
@@ -215,7 +209,6 @@ func TestRepoTagsSource_LastVersionHash(t *testing.T) {
 			name: "Matching_Leading_v",
 			tagOpts: []git.TagOptionFunc{
 				git.TagsMatchingRegex("^v"),
-				git.TagsMatchingCommits(commitsGetter),
 			},
 			expectedHash: getVersionCommitHash(t, repodir, "v1.4.0"),
 		},
@@ -223,7 +216,6 @@ func TestRepoTagsSource_LastVersionHash(t *testing.T) {
 			name: "Matching_And_Replacing_Prefix",
 			tagOpts: []git.TagOptionFunc{
 				git.TagsMatchingRegex("^helm-chart-"),
-				git.TagsMatchingCommits(commitsGetter),
 			},
 			tagSourceOpts: []git.TagSourceOptionFunc{
 				git.TagSourceReplacing("helm-chart-", ""),


### PR DESCRIPTION
Fix https://github.com/newrelic/release-toolkit/issues/109

The approach is quite simple, we check all tags and discard the ones not found in the list of commits since the root one (following the history).

```
rt validate-markdown --markdown "charts/newrelic-prometheus-agent"/CHANGELOG.md
rt generate-yaml --markdown "charts/newrelic-prometheus-agent"/CHANGELOG.md --included-dirs "charts/newrelic-prometheus-agent"  --tag-prefix newrelic-prometheus-agent-
INFO[0000] Ignoring newrelic-prometheus-agent-0.0.6 since it belongs to a different branch 
INFO[0000] Ignoring newrelic-prometheus-agent-0.0.7 since it belongs to a different branch 
INFO[0000] Ignoring newrelic-prometheus-agent-0.1.0 since it belongs to a different branch 
INFO[0000] Renovate source did not find any commit since "25153bf1101695b03f8a572b395f0070d39387fd" 
```
<img width="1089" alt="Screenshot 2022-10-11 at 16 56 06" src="https://user-images.githubusercontent.com/43335750/195126094-fddde424-c06b-4cbe-ad76-377f6727ce4b.png">

