### PR TITLE
entry: better separate external changelog link

### DIFF
--- a/src/changelog/changelog.go
+++ b/src/changelog/changelog.go
@@ -167,7 +167,7 @@ func (d Dependency) String() string {
 	}
 
 	if d.Changelog != "" {
-		_, _ = fmt.Fprintf(buf, " [Changelog](%s)", d.Changelog)
+		_, _ = fmt.Fprintf(buf, " - [Changelog 🔗](%s)", d.Changelog)
 	}
 
 	return buf.String()

--- a/src/changelog/renderer/renderer_test.go
+++ b/src/changelog/renderer/renderer_test.go
@@ -17,7 +17,7 @@ func brokenWristwatch() time.Time {
 	return t
 }
 
-//nolint:funlen
+//nolint:funlen,maintidx
 func TestRenderer_Render(t *testing.T) {
 	t.Parallel()
 
@@ -235,6 +235,27 @@ I am a note!
 
 ### 🐞 Bug fixes
 - Fixed a bug that was causing everything to explode, by @roobre (#1337)
+`),
+		},
+		{
+			name:    "Changelog_Only_Dependencies",
+			date:    brokenWristwatch,
+			version: semver.MustParse("0.0.0"),
+			changelog: changelog.Changelog{
+				Dependencies: []changelog.Dependency{
+					{
+						Name:      "Test dependency",
+						From:      semver.MustParse("v1.2.3"),
+						To:        semver.MustParse("v1.2.4"),
+						Changelog: "https://foo.bar/baz",
+					},
+				},
+			},
+			expected: strings.TrimSpace(`
+## v0.0.0 - 1993-09-21
+
+### ⛓️ Dependencies
+- Upgraded Test dependency from v1.2.3 to v1.2.4 - [Changelog 🔗](https://foo.bar/baz)
 `),
 		},
 		{


### PR DESCRIPTION
Currently, text output for dependency changelogs looks like the following: 

> ### ⛓️ Dependencies
> - Upgraded [github.com/prometheus/prometheus](http://github.com/prometheus/prometheus) from 0.37.2 to 0.37.3 [Changelog](https://github.com/prometheus/prometheus/releases/tag/0.37.3)

The `Changelog` does not have any separation from the rest of the text, making it look aesthetically unpleasant.

This PR changes it so it looks like the following:

> ### ⛓️ Dependencies
> - Upgraded [github.com/prometheus/prometheus](http://github.com/prometheus/prometheus) from 0.37.2 to 0.37.3 - [Changelog 🔗](https://github.com/prometheus/prometheus/releases/tag/0.37.3)

