### PR TITLE
git/test: specify default branch name on git init

### DIFF
--- a/src/git/tag_source_test.go
+++ b/src/git/tag_source_test.go
@@ -16,7 +16,8 @@ func repoWithTags(t *testing.T, tags ...string) string {
 	dir := t.TempDir()
 
 	cmds := []string{
-		"git init",
+		// Set default branch name to `master`, as tests assume that later.
+		"git init --initial-branch master",
 		"git config user.email test@user.tld",
 		"git config user.name Test",
 		"git config commit.gpgsign false",


### PR DESCRIPTION
Before this commit, tests would fail if they are run on an environment where the user has git configured to use a default branch name that is not `master` (e.g. `main`). This PR fixes that by instructing `git init` to use a predictable name for the deafault branch.