### PR TITLE
sources/markdown: fix leading spaces in list items causing a panic

### DIFF
--- a/src/changelog/sources/markdown/filter.go
+++ b/src/changelog/sources/markdown/filter.go
@@ -1,0 +1,38 @@
+package markdown
+
+import (
+	"io"
+	"reflect"
+
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/ast"
+)
+
+// FilterRenderer wraps a markdown.Renderer skips calling it for certain node types.
+// This allows to use the default markdown renderer with types it does not support without it panicking.
+type FilterRenderer struct {
+	filtered map[reflect.Type]bool
+	markdown.Renderer
+}
+
+// NewFilterRenderer returns a FilterRenderer given an underlying renderer and a list of nodes whose type will be ignored.
+func NewFilterRenderer(inner markdown.Renderer, ignore ...ast.Node) FilterRenderer {
+	filtered := map[reflect.Type]bool{}
+	for _, iface := range ignore {
+		filtered[reflect.TypeOf(iface)] = true
+	}
+
+	return FilterRenderer{
+		filtered: filtered,
+		Renderer: inner,
+	}
+}
+
+// RenderNode implements markdown.Renderer with the additional filtering logic.
+func (fr FilterRenderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.WalkStatus {
+	if fr.filtered[reflect.TypeOf(node)] {
+		return ast.GoToNext
+	}
+
+	return fr.Renderer.RenderNode(w, node, entering)
+}

--- a/src/changelog/sources/markdown/filter_test.go
+++ b/src/changelog/sources/markdown/filter_test.go
@@ -1,0 +1,30 @@
+package markdown_test
+
+import (
+	"testing"
+
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/md"
+	"github.com/gomarkdown/markdown/parser"
+)
+
+const list = `
+- This is a list
+- This line has trailing spaces   
+- This one has not
+`
+
+func TestRendererPanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Log("Markdown renderer panicked as expected, FilterRenderer is still necessary.")
+		}
+	}()
+
+	doc := parser.New().Parse([]byte(list))
+	markdown.Render(doc, md.NewRenderer())
+
+	t.Errorf("Makrdown renderer did not panic when rendering an *ast.Hardbreak. Our homemade FilterRenderer should be removed.")
+}

--- a/src/changelog/sources/markdown/filter_test.go
+++ b/src/changelog/sources/markdown/filter_test.go
@@ -1,11 +1,14 @@
 package markdown_test
 
 import (
+	"io"
 	"testing"
 
 	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/ast"
 	"github.com/gomarkdown/markdown/md"
 	"github.com/gomarkdown/markdown/parser"
+	filterer "github.com/newrelic/release-toolkit/src/changelog/sources/markdown"
 )
 
 const list = `
@@ -27,4 +30,60 @@ func TestRendererPanics(t *testing.T) {
 	markdown.Render(doc, md.NewRenderer())
 
 	t.Errorf("Makrdown renderer did not panic when rendering an *ast.Hardbreak. Our homemade FilterRenderer should be removed.")
+}
+
+type mockRenderer struct {
+	called int
+}
+
+func (mr *mockRenderer) RenderNode(w io.Writer, node ast.Node, entering bool) ast.WalkStatus {
+	mr.called++
+	return ast.GoToNext
+}
+func (mr *mockRenderer) RenderHeader(w io.Writer, ast ast.Node) {}
+func (mr *mockRenderer) RenderFooter(w io.Writer, ast ast.Node) {}
+
+func TestFilterRenderer(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		nodes        []ast.Node
+		ignore       []ast.Node
+		expectCalled int
+	}{
+		{
+			name: "Skips_Nodes",
+			nodes: []ast.Node{
+				&ast.Paragraph{},
+				&ast.Heading{},
+				&ast.Image{},
+				&ast.List{},
+				&ast.ListItem{},
+			},
+			ignore: []ast.Node{
+				&ast.Image{},
+				&ast.List{},
+			},
+			expectCalled: 3,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &mockRenderer{}
+			fr := filterer.NewFilterRenderer(mock, tc.ignore...)
+
+			for _, node := range tc.nodes {
+				fr.RenderNode(nil, node, false)
+			}
+
+			if mock.called != tc.expectCalled {
+				t.Fatalf("Expected to render %d nodes, rendered %d", tc.expectCalled, mock.called)
+			}
+		})
+	}
 }

--- a/src/changelog/sources/markdown/md.go
+++ b/src/changelog/sources/markdown/md.go
@@ -142,6 +142,9 @@ func (b builder) unvisitedAsNotes(header *headingdoc.Doc) {
 func items(content []ast.Node) []string {
 	var itemsStr []string
 
+	// FilterRenderer uses the default renderer, but skips feeding it *ast.Hardbreaks, which would make it panic.
+	renderer := NewFilterRenderer(md.NewRenderer(), &ast.Hardbreak{})
+
 	for _, node := range content {
 		list, isList := node.(*ast.List)
 		if !isList {
@@ -161,7 +164,7 @@ func items(content []ast.Node) []string {
 				continue
 			}
 
-			buf := markdown.Render(item.Children[0], md.NewRenderer())
+			buf := markdown.Render(item.Children[0], renderer)
 			itemsStr = append(itemsStr, strings.TrimSpace(string(buf)))
 		}
 	}

--- a/src/changelog/sources/markdown/md_test.go
+++ b/src/changelog/sources/markdown/md_test.go
@@ -63,6 +63,32 @@ This is a release note
 			},
 		},
 		{
+			name: "Parses_Trailing spaces",
+			markdown: strings.TrimSpace(`
+# Changelog
+This is based on blah blah blah
+
+## Unreleased
+
+### Enhancements
+- This line has trailing spaces   
+
+### Bugfixes
+- Fixed a bug that caused the world to end
+
+## v1.2.3 - 20YY-DD-MM
+
+### Enhancements
+- This is in the past and should not be included
+`),
+			expected: &cl.Changelog{
+				Changes: []cl.Entry{
+					{Type: cl.TypeEnhancement, Message: "This line has trailing spaces"},
+					{Type: cl.TypeBugfix, Message: "Fixed a bug that caused the world to end"},
+				},
+			},
+		},
+		{
 			name: "Parses_Held_L2_Header",
 			markdown: strings.TrimSpace(`
 # Changelog

--- a/src/changelog/sources/markdown/md_test.go
+++ b/src/changelog/sources/markdown/md_test.go
@@ -71,10 +71,10 @@ This is based on blah blah blah
 ## Unreleased
 
 ### Enhancements
-- This line has trailing spaces   
+- This line DOES NOT HAVE trailing spaces
 
 ### Bugfixes
-- Fixed a bug that caused the world to end
+- This line has trailing spaces  
 
 ## v1.2.3 - 20YY-DD-MM
 
@@ -83,8 +83,8 @@ This is based on blah blah blah
 `),
 			expected: &cl.Changelog{
 				Changes: []cl.Entry{
-					{Type: cl.TypeEnhancement, Message: "This line has trailing spaces"},
-					{Type: cl.TypeBugfix, Message: "Fixed a bug that caused the world to end"},
+					{Type: cl.TypeEnhancement, Message: "This line DOES NOT HAVE trailing spaces"},
+					{Type: cl.TypeBugfix, Message: "This line has trailing spaces"},
 				},
 			},
 		},


### PR DESCRIPTION
Two or more leading spaces on a list item causes the markdown parser to include an `*ast.Hardbreak` node after the usual `*ast.Paragraph` one. This should not be a concern, but it turns out the markdown renderer is not able to render `*ast.Hardbreak`, and it panics when they are fed to it.

This PR works around that by introducing a `FilterRenderer`, which thinly wraps a `markdown.Renderer` but skips passing it nodes it does not support.

PR also comes with a test that will fail if this hack is no longer necessary.

Closes #121 