### PR TITLE
Add version limit to next-version command (NR-79791)

### DIFF
--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -3,6 +3,7 @@ package nextversion
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/newrelic/release-toolkit/src/app/common"
@@ -115,8 +116,8 @@ func NextVersion(cCtx *cli.Context) error {
 		return err
 	}
 
-	entryCap := bump.NameToType(cCtx.String(limitVersionBumpToFlag))
-	dependencyCap := bump.NameToType(cCtx.String(limitDependencyBumpToFlag))
+	entryCap := bump.NameToType(strings.ToLower(cCtx.String(limitVersionBumpToFlag)))
+	dependencyCap := bump.NameToType(strings.ToLower(cCtx.String(limitDependencyBumpToFlag)))
 
 	bmpr := bumper.New(
 		ch,

--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -117,11 +117,11 @@ func NextVersion(cCtx *cli.Context) error {
 
 	entryCap, err := bump.NameToType(cCtx.String(BumpCapFlag))
 	if err != nil {
-		return fmt.Errorf("error with the changes' cap: %w", err)
+		return fmt.Errorf("parsing version bump cap: %w", err)
 	}
 	dependencyCap, err := bump.NameToType(cCtx.String(DependencyCapFlag))
 	if err != nil {
-		return fmt.Errorf("error with dependencies' cap: %w", err)
+		return fmt.Errorf("parsing dependency bump: %w", err)
 	}
 
 	bmpr := bumper.New(ch)

--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -119,11 +119,10 @@ func NextVersion(cCtx *cli.Context) error {
 	entryCap := bump.NameToType(strings.ToLower(cCtx.String(BumpCapFlag)))
 	dependencyCap := bump.NameToType(strings.ToLower(cCtx.String(DependencyCapFlag)))
 
-	bmpr := bumper.New(
-		ch,
-		bumper.WithEntryCap(entryCap),
-		bumper.WithDependencyCap(dependencyCap),
-	)
+	bmpr := bumper.New(ch)
+	bmpr.EntryCap = entryCap
+	bmpr.DependencyCap = dependencyCap
+
 	next, err := bmpr.BumpSource(versionSrc)
 
 	nextStr := ""

--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/newrelic/release-toolkit/src/app/common"
 	"github.com/newrelic/release-toolkit/src/app/gha"
+	"github.com/newrelic/release-toolkit/src/bump"
 	"github.com/newrelic/release-toolkit/src/bumper"
 	"github.com/newrelic/release-toolkit/src/changelog"
 	"github.com/newrelic/release-toolkit/src/git"
@@ -17,11 +18,13 @@ import (
 )
 
 const (
-	outputPrefix = "output-prefix"
-	tagPrefix    = "tag-prefix"
-	currentFlag  = "current"
-	nextFlag     = "next"
-	gitRootFlag  = "git-root"
+	outputPrefix              = "output-prefix"
+	tagPrefix                 = "tag-prefix"
+	currentFlag               = "current"
+	nextFlag                  = "next"
+	gitRootFlag               = "git-root"
+	limitVersionBumpToFlag    = "limit-version-bump-to"
+	limitDependencyBumpToFlag = "limit-dependency-bump-to"
 )
 
 const nextVersionOutput = "next-version"
@@ -67,6 +70,18 @@ Several flags can be specified to limit the set of tags that are scanned, and to
 			Usage:   "Path to the git repo to find tags on.",
 			Value:   "./",
 		},
+		&cli.StringFlag{
+			Name:    limitVersionBumpToFlag,
+			EnvVars: common.EnvFor(limitVersionBumpToFlag),
+			Usage:   "In case of having to bump the version of the package, limit to this semVer type",
+			Value:   string(bump.MajorName),
+		},
+		&cli.StringFlag{
+			Name:    limitDependencyBumpToFlag,
+			EnvVars: common.EnvFor(limitDependencyBumpToFlag),
+			Usage:   "In case of having to bump the version of base on a dependency, limit to this semVer type",
+			Value:   string(bump.MajorName),
+		},
 	},
 	Action: NextVersion,
 }
@@ -100,7 +115,14 @@ func NextVersion(cCtx *cli.Context) error {
 		return err
 	}
 
-	bmpr := bumper.New(ch)
+	entryCap := bump.NameToType(cCtx.String(limitVersionBumpToFlag))
+	dependencyCap := bump.NameToType(cCtx.String(limitDependencyBumpToFlag))
+
+	bmpr := bumper.New(
+		ch,
+		bumper.WithEntryCap(entryCap),
+		bumper.WithDependencyCap(dependencyCap),
+	)
 	next, err := bmpr.BumpSource(versionSrc)
 
 	nextStr := ""

--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -3,7 +3,6 @@ package nextversion
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/newrelic/release-toolkit/src/app/common"
@@ -116,8 +115,14 @@ func NextVersion(cCtx *cli.Context) error {
 		return err
 	}
 
-	entryCap := bump.NameToType(strings.ToLower(cCtx.String(BumpCapFlag)))
-	dependencyCap := bump.NameToType(strings.ToLower(cCtx.String(DependencyCapFlag)))
+	entryCap, err := bump.NameToType(cCtx.String(BumpCapFlag))
+	if err != nil {
+		return fmt.Errorf("error with the changes' cap: %w", err)
+	}
+	dependencyCap, err := bump.NameToType(cCtx.String(DependencyCapFlag))
+	if err != nil {
+		return fmt.Errorf("error with dependencies' cap: %w", err)
+	}
 
 	bmpr := bumper.New(ch)
 	bmpr.EntryCap = entryCap

--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -19,13 +19,13 @@ import (
 )
 
 const (
-	outputPrefix              = "output-prefix"
-	tagPrefix                 = "tag-prefix"
-	currentFlag               = "current"
-	nextFlag                  = "next"
-	gitRootFlag               = "git-root"
-	limitVersionBumpToFlag    = "limit-version-bump-to"
-	limitDependencyBumpToFlag = "limit-dependency-bump-to"
+	outputPrefix      = "output-prefix"
+	tagPrefix         = "tag-prefix"
+	currentFlag       = "current"
+	nextFlag          = "next"
+	gitRootFlag       = "git-root"
+	BumpCapFlag       = "bump-cap"
+	DependencyCapFlag = "dependency-cap"
 )
 
 const nextVersionOutput = "next-version"
@@ -72,14 +72,14 @@ Several flags can be specified to limit the set of tags that are scanned, and to
 			Value:   "./",
 		},
 		&cli.StringFlag{
-			Name:    limitVersionBumpToFlag,
-			EnvVars: common.EnvFor(limitVersionBumpToFlag),
+			Name:    BumpCapFlag,
+			EnvVars: common.EnvFor(BumpCapFlag),
 			Usage:   "In case of having to bump the version of the package, limit to this semVer type",
 			Value:   string(bump.MajorName),
 		},
 		&cli.StringFlag{
-			Name:    limitDependencyBumpToFlag,
-			EnvVars: common.EnvFor(limitDependencyBumpToFlag),
+			Name:    DependencyCapFlag,
+			EnvVars: common.EnvFor(DependencyCapFlag),
 			Usage:   "In case of having to bump the version of base on a dependency, limit to this semVer type",
 			Value:   string(bump.MajorName),
 		},
@@ -116,8 +116,8 @@ func NextVersion(cCtx *cli.Context) error {
 		return err
 	}
 
-	entryCap := bump.NameToType(strings.ToLower(cCtx.String(limitVersionBumpToFlag)))
-	dependencyCap := bump.NameToType(strings.ToLower(cCtx.String(limitDependencyBumpToFlag)))
+	entryCap := bump.NameToType(strings.ToLower(cCtx.String(BumpCapFlag)))
+	dependencyCap := bump.NameToType(strings.ToLower(cCtx.String(DependencyCapFlag)))
 
 	bmpr := bumper.New(
 		ch,

--- a/src/app/nextversion/nextversion_test.go
+++ b/src/app/nextversion/nextversion_test.go
@@ -249,7 +249,7 @@ changes:
 		{
 			name:     "Major_Capped_To_Minor",
 			expected: "v2.1.0",
-			args:     "--limit-version-bump-to=minor",
+			args:     "--bump-cap=minor",
 			yaml: strings.TrimSpace(`
 notes: |-
     ### Important announcement (note)
@@ -263,7 +263,7 @@ changes:
 		{
 			name:     "Major_Capped_To_Patch",
 			expected: "v2.0.1",
-			args:     "--limit-version-bump-to=patch",
+			args:     "--bump-cap=patch",
 			yaml: strings.TrimSpace(`
 notes: |-
     ### Important announcement (note)
@@ -277,7 +277,7 @@ changes:
 		{
 			name:     "Major_From_Dependency_Capped_To_Minor",
 			expected: "v2.1.0",
-			args:     "--limit-dependency-bump-to=minor",
+			args:     "--dependency-cap=minor",
 			yaml: strings.TrimSpace(`
 notes: |-
     ### Important announcement (note)
@@ -292,7 +292,7 @@ dependencies:
 		{
 			name:     "Major_From_Dependency_Capped_To_Patch",
 			expected: "v2.0.1",
-			args:     "--limit-dependency-bump-to=patch",
+			args:     "--dependency-cap=patch",
 			yaml: strings.TrimSpace(`
 notes: |-
     ### Important announcement (note)

--- a/src/app/nextversion/nextversion_test.go
+++ b/src/app/nextversion/nextversion_test.go
@@ -246,6 +246,64 @@ changes:
   message: New feature has been added
 			`),
 		},
+		{
+			name:     "Major_Capped_To_Minor",
+			expected: "v2.1.0",
+			args:     "--limit-version-bump-to=minor",
+			yaml: strings.TrimSpace(`
+notes: |-
+    ### Important announcement (note)
+
+    This is a release note
+changes:
+- type: breaking
+  message: Support has been removed
+			`),
+		},
+		{
+			name:     "Major_Capped_To_Patch",
+			expected: "v2.0.1",
+			args:     "--limit-version-bump-to=patch",
+			yaml: strings.TrimSpace(`
+notes: |-
+    ### Important announcement (note)
+
+    This is a release note
+changes:
+- type: breaking
+  message: Support has been removed
+			`),
+		},
+		{
+			name:     "Major_From_Dependency_Capped_To_Minor",
+			expected: "v2.1.0",
+			args:     "--limit-dependency-bump-to=minor",
+			yaml: strings.TrimSpace(`
+notes: |-
+    ### Important announcement (note)
+
+    This is a release note
+dependencies:
+- name: foobar
+  from: 0.0.1
+  to: 1.0.0
+			`),
+		},
+		{
+			name:     "Major_From_Dependency_Capped_To_Patch",
+			expected: "v2.0.1",
+			args:     "--limit-dependency-bump-to=patch",
+			yaml: strings.TrimSpace(`
+notes: |-
+    ### Important announcement (note)
+
+    This is a release note
+dependencies:
+- name: foobar
+  from: 0.0.1
+  to: 1.0.0
+			`),
+		},
 	} {
 		tc := tc
 		//nolint:paralleltest // urfave/cli cannot be tested concurrently.

--- a/src/bump/type.go
+++ b/src/bump/type.go
@@ -80,8 +80,9 @@ func Bump(version *semver.Version, bt Type) *semver.Version {
 }
 
 // NameToType returns the bump type from a string. The string should be from a constant constant of bump.Name
-// or it will return bump.None
+// or it will return bump.None.
 func NameToType(name string) Type {
+	//nolint:exhaustive // case NoneName is captured in the last default clause.
 	switch Name(name) {
 	case PatchName:
 		return Patch

--- a/src/bump/type.go
+++ b/src/bump/type.go
@@ -2,6 +2,7 @@ package bump
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/Masterminds/semver"
@@ -25,7 +26,7 @@ const (
 	MajorName = Name("major")
 )
 
-var ErrNameNotValid = errors.New("name introduced is not valid (not in \"none\", \"patch\", \"minor\", or \"major\")")
+var ErrNameNotValid = errors.New("name introduced is not valid")
 
 // Less returns whether the current bump Type is smaller than another one.
 func (bt Type) Less(other Type) bool {
@@ -104,6 +105,6 @@ func NameToType(name string) (Type, error) {
 	case NoneName:
 		return None, nil
 	default:
-		return None, ErrNameNotValid
+		return None, fmt.Errorf("the name %s is (not in \"none\", \"patch\", \"minor\", or \"major\"): %w", name, ErrNameNotValid)
 	}
 }

--- a/src/bump/type.go
+++ b/src/bump/type.go
@@ -1,6 +1,11 @@
 package bump
 
-import "github.com/Masterminds/semver"
+import (
+	"errors"
+	"strings"
+
+	"github.com/Masterminds/semver"
+)
 
 type Type int
 
@@ -19,6 +24,8 @@ const (
 	MinorName = Name("minor")
 	MajorName = Name("major")
 )
+
+var ErrNameNotValid = errors.New("name introduced is not valid (not in \"none\", \"patch\", \"minor\", or \"major\")")
 
 // Less returns whether the current bump Type is smaller than another one.
 func (bt Type) Less(other Type) bool {
@@ -84,16 +91,19 @@ func Bump(version *semver.Version, bt Type) *semver.Version {
 
 // NameToType returns the bump type from a string. The string should be from a constant constant of bump.Name
 // or it will return bump.None.
-func NameToType(name string) Type {
-	//nolint:exhaustive // case NoneName is captured in the last default clause.
-	switch Name(name) {
+func NameToType(name string) (Type, error) {
+	n := strings.ToLower(name)
+
+	switch Name(n) {
 	case PatchName:
-		return Patch
+		return Patch, nil
 	case MinorName:
-		return Minor
+		return Minor, nil
 	case MajorName:
-		return Major
+		return Major, nil
+	case NoneName:
+		return None, nil
 	default:
-		return None
+		return None, ErrNameNotValid
 	}
 }

--- a/src/bump/type.go
+++ b/src/bump/type.go
@@ -3,14 +3,17 @@ package bump
 import "github.com/Masterminds/semver"
 
 type Type int
-type Name string
 
 const (
 	None  = Type(0)
 	Patch = Type(1)
 	Minor = Type(2)
 	Major = Type(3)
+)
 
+type Name string
+
+const (
 	NoneName  = Name("none")
 	PatchName = Name("patch")
 	MinorName = Name("minor")

--- a/src/bump/type.go
+++ b/src/bump/type.go
@@ -3,12 +3,18 @@ package bump
 import "github.com/Masterminds/semver"
 
 type Type int
+type Name string
 
 const (
 	None  = Type(0)
 	Patch = Type(1)
 	Minor = Type(2)
 	Major = Type(3)
+
+	NoneName  = Name("none")
+	PatchName = Name("patch")
+	MinorName = Name("minor")
+	MajorName = Name("major")
 )
 
 // Less returns whether the current bump Type is smaller than another one.
@@ -71,4 +77,19 @@ func Bump(version *semver.Version, bt Type) *semver.Version {
 	}
 
 	return &v
+}
+
+// NameToType returns the bump type from a string. The string should be from a constant constant of bump.Name
+// or it will return bump.None
+func NameToType(name string) Type {
+	switch Name(name) {
+	case PatchName:
+		return Patch
+	case MinorName:
+		return Minor
+	case MajorName:
+		return Major
+	default:
+		return None
+	}
 }

--- a/src/bumper/bumper.go
+++ b/src/bumper/bumper.go
@@ -16,41 +16,16 @@ var ErrNoTags = errors.New("source did not return any tag")
 // Bumper takes a changelog and a version and figures out the next one.
 type Bumper struct {
 	changelog     changelog.Changelog
-	entryCap      bump.Type
-	dependencyCap bump.Type
+	EntryCap      bump.Type
+	DependencyCap bump.Type
 }
-
-// BumperOption is the interface to add options to the bumper.
-//
-//nolint:revive // Following the options pattern here. Renaming it to `option` could lead to a misunderstanding.
-type BumperOption func(bumper *Bumper)
 
 // New creates a new bumper.
-func New(c changelog.Changelog, opts ...BumperOption) Bumper {
-	bumper := Bumper{
+func New(c changelog.Changelog) Bumper {
+	return Bumper{
 		changelog:     c,
-		entryCap:      bump.Major,
-		dependencyCap: bump.Major,
-	}
-
-	for _, opt := range opts {
-		opt(&bumper)
-	}
-
-	return bumper
-}
-
-// Allows to cap the version bump that was calculated from the entries in the changelog.
-func WithEntryCap(t bump.Type) BumperOption {
-	return func(b *Bumper) {
-		b.entryCap = t
-	}
-}
-
-// Allows to cap the version bump that was calculated from the dependencies.
-func WithDependencyCap(t bump.Type) BumperOption {
-	return func(b *Bumper) {
-		b.dependencyCap = t
+		EntryCap:      bump.Major,
+		DependencyCap: bump.Major,
 	}
 }
 
@@ -60,13 +35,13 @@ func (b Bumper) Bump(v *semver.Version) (*semver.Version, error) {
 	for _, e := range b.changelog.Changes {
 		entryBump = entryBump.With(e.BumpType())
 	}
-	entryBump = entryBump.Cap(b.entryCap)
+	entryBump = entryBump.Cap(b.EntryCap)
 
 	dependencyBump := bump.None
 	for _, d := range b.changelog.Dependencies {
 		dependencyBump = dependencyBump.With(d.BumpType())
 	}
-	dependencyBump = dependencyBump.Cap(b.dependencyCap)
+	dependencyBump = dependencyBump.Cap(b.DependencyCap)
 
 	return bump.Bump(v, entryBump.With(dependencyBump)), nil
 }

--- a/src/bumper/bumper.go
+++ b/src/bumper/bumper.go
@@ -20,6 +20,9 @@ type Bumper struct {
 	dependencyCap bump.Type
 }
 
+// BumperOption is the interface to add options to the bumper.
+//
+//nolint:revive // Following the options pattern here. Renaming it to `option` could lead to a misunderstanding.
 type BumperOption func(bumper *Bumper)
 
 // New creates a new bumper.
@@ -37,13 +40,14 @@ func New(c changelog.Changelog, opts ...BumperOption) Bumper {
 	return bumper
 }
 
-// Allows to limit the .
+// Allows to cap the version bump that was calculated from the entries in the changelog.
 func WithEntryCap(t bump.Type) BumperOption {
 	return func(b *Bumper) {
 		b.entryCap = t
 	}
 }
 
+// Allows to cap the version bump that was calculated from the dependencies.
 func WithDependencyCap(t bump.Type) BumperOption {
 	return func(b *Bumper) {
 		b.dependencyCap = t

--- a/src/bumper/bumper_test.go
+++ b/src/bumper/bumper_test.go
@@ -26,10 +26,10 @@ type testCaseWithCap struct {
 	dependencyCap bump.Type
 }
 
-func TestBumper_Bump(t *testing.T) {
+func TestBumper_Bump_changesOnlyCases(t *testing.T) {
 	t.Parallel()
 
-	changesOnlyCases := []testCase{
+	testCases := []testCase{
 		{
 			name:     "Patch_On_Bugfixes_Only",
 			current:  semver.MustParse("v1.2.3"),
@@ -63,7 +63,28 @@ func TestBumper_Bump(t *testing.T) {
 		},
 	}
 
-	depsOnlyCases := []testCase{
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bumper := bumper.New(tc.changelog)
+			next, err := bumper.Bump(tc.current)
+			if err != nil {
+				t.Fatalf("Bumping version: %v", err)
+			}
+
+			if !tc.expected.Equal(next) {
+				t.Fatalf("Expected %v, got %v", tc.expected, next)
+			}
+		})
+	}
+}
+
+func TestBumper_Bump_depsOnlyCases(t *testing.T) {
+	t.Parallel()
+
+	testCases := []testCase{
 		{
 			name:     "Patch_On_Deps_Patch",
 			current:  semver.MustParse("v1.2.3"),
@@ -96,7 +117,27 @@ func TestBumper_Bump(t *testing.T) {
 		},
 	}
 
-	mixedCases := []testCase{
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bumper := bumper.New(tc.changelog)
+			next, err := bumper.Bump(tc.current)
+			if err != nil {
+				t.Fatalf("Bumping version: %v", err)
+			}
+
+			if !tc.expected.Equal(next) {
+				t.Fatalf("Expected %v, got %v", tc.expected, next)
+			}
+		})
+	}
+}
+func TestBumper_Bump_mixedCases(t *testing.T) {
+	t.Parallel()
+
+	testCases := []testCase{
 		{
 			name:     "Enhancement_and_Patch_On_Deps_Minor",
 			current:  semver.MustParse("v1.2.3"),
@@ -126,11 +167,6 @@ func TestBumper_Bump(t *testing.T) {
 		},
 	}
 
-	testCases := []testCase{}
-	testCases = append(testCases, changesOnlyCases...)
-	testCases = append(testCases, depsOnlyCases...)
-	testCases = append(testCases, mixedCases...)
-
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -149,10 +185,10 @@ func TestBumper_Bump(t *testing.T) {
 	}
 }
 
-func TestBumper_BumpWithCap(t *testing.T) {
+func TestBumper_BumpWithCap_changesOnlyCases(t *testing.T) {
 	t.Parallel()
 
-	changesOnlyCases := []testCaseWithCap{
+	testCases := []testCaseWithCap{
 		{
 			name:     "Minor_Change_limit_to_patch",
 			current:  semver.MustParse("v1.2.3"),
@@ -189,7 +225,32 @@ func TestBumper_BumpWithCap(t *testing.T) {
 		},
 	}
 
-	depsOnlyCases := []testCaseWithCap{
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bumper := bumper.New(
+				tc.changelog,
+				bumper.WithEntryCap(tc.entryCap),
+				bumper.WithDependencyCap(tc.dependencyCap),
+			)
+			next, err := bumper.Bump(tc.current)
+			if err != nil {
+				t.Fatalf("Bumping version: %v", err)
+			}
+
+			if !tc.expected.Equal(next) {
+				t.Fatalf("Expected %v, got %v", tc.expected, next)
+			}
+		})
+	}
+}
+
+func TestBumper_BumpWithCap_depsOnlyCases(t *testing.T) {
+	t.Parallel()
+
+	testCases := []testCaseWithCap{
 		{
 			name:     "Minor_dep_limited_to_patch",
 			current:  semver.MustParse("v1.2.3"),
@@ -225,7 +286,32 @@ func TestBumper_BumpWithCap(t *testing.T) {
 		},
 	}
 
-	mixedCases := []testCaseWithCap{
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bumper := bumper.New(
+				tc.changelog,
+				bumper.WithEntryCap(tc.entryCap),
+				bumper.WithDependencyCap(tc.dependencyCap),
+			)
+			next, err := bumper.Bump(tc.current)
+			if err != nil {
+				t.Fatalf("Bumping version: %v", err)
+			}
+
+			if !tc.expected.Equal(next) {
+				t.Fatalf("Expected %v, got %v", tc.expected, next)
+			}
+		})
+	}
+}
+
+func TestBumper_BumpWithCap_mixedCases(t *testing.T) {
+	t.Parallel()
+
+	testCases := []testCaseWithCap{
 		{
 			name:     "Breaking_change_limited_to_patch_and_major_dep_limited_to_minor",
 			current:  semver.MustParse("v1.2.3"),
@@ -256,11 +342,6 @@ func TestBumper_BumpWithCap(t *testing.T) {
 			dependencyCap: bump.Patch,
 		},
 	}
-
-	testCases := []testCaseWithCap{}
-	testCases = append(testCases, changesOnlyCases...)
-	testCases = append(testCases, depsOnlyCases...)
-	testCases = append(testCases, mixedCases...)
 
 	for _, tc := range testCases {
 		tc := tc

--- a/src/bumper/bumper_test.go
+++ b/src/bumper/bumper_test.go
@@ -134,6 +134,7 @@ func TestBumper_Bump_depsOnlyCases(t *testing.T) {
 		})
 	}
 }
+
 func TestBumper_Bump_mixedCases(t *testing.T) {
 	t.Parallel()
 

--- a/src/bumper/bumper_test.go
+++ b/src/bumper/bumper_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver"
+	"github.com/newrelic/release-toolkit/src/bump"
 	"github.com/newrelic/release-toolkit/src/bumper"
 	"github.com/newrelic/release-toolkit/src/changelog"
 )
@@ -14,6 +15,15 @@ type testCase struct {
 	changelog changelog.Changelog
 	current   *semver.Version
 	expected  *semver.Version
+}
+
+type testCaseWithCap struct {
+	name          string
+	changelog     changelog.Changelog
+	current       *semver.Version
+	expected      *semver.Version
+	entryCap      bump.Type
+	dependencyCap bump.Type
 }
 
 func TestBumper_Bump(t *testing.T) {
@@ -86,12 +96,182 @@ func TestBumper_Bump(t *testing.T) {
 		},
 	}
 
-	for _, tc := range append(changesOnlyCases, depsOnlyCases...) {
+	mixedCases := []testCase{
+		{
+			name:     "Enhancement_and_Patch_On_Deps_Minor",
+			current:  semver.MustParse("v1.2.3"),
+			expected: semver.MustParse("v1.3.0"),
+			changelog: changelog.Changelog{
+				Changes: []changelog.Entry{
+					{Type: changelog.TypeEnhancement},
+					{Type: changelog.TypeSecurity},
+				},
+				Dependencies: []changelog.Dependency{
+					{From: semver.MustParse("v9.9.9"), To: semver.MustParse("v9.9.10")},
+				},
+			},
+		},
+		{
+			name:     "Bugfix_and_Minor_On_Deps_Minor",
+			current:  semver.MustParse("v1.2.3"),
+			expected: semver.MustParse("v1.3.0"),
+			changelog: changelog.Changelog{
+				Changes: []changelog.Entry{
+					{Type: changelog.TypeBugfix},
+				},
+				Dependencies: []changelog.Dependency{
+					{From: semver.MustParse("v9.9.9"), To: semver.MustParse("v9.10.9")},
+				},
+			},
+		},
+	}
+
+	testCases := []testCase{}
+	testCases = append(testCases, changesOnlyCases...)
+	testCases = append(testCases, depsOnlyCases...)
+	testCases = append(testCases, mixedCases...)
+
+	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			bumper := bumper.New(tc.changelog)
+			next, err := bumper.Bump(tc.current)
+			if err != nil {
+				t.Fatalf("Bumping version: %v", err)
+			}
+
+			if !tc.expected.Equal(next) {
+				t.Fatalf("Expected %v, got %v", tc.expected, next)
+			}
+		})
+	}
+}
+
+func TestBumper_BumpWithCap(t *testing.T) {
+	t.Parallel()
+
+	changesOnlyCases := []testCaseWithCap{
+		{
+			name:     "Minor_Change_limit_to_patch",
+			current:  semver.MustParse("v1.2.3"),
+			expected: semver.MustParse("v1.2.4"),
+			changelog: changelog.Changelog{
+				Changes: []changelog.Entry{
+					{Type: changelog.TypeEnhancement},
+					{Type: changelog.TypeSecurity},
+				},
+			},
+			entryCap: bump.Patch,
+		},
+		{
+			name:     "Major_change_limit_to_patch",
+			current:  semver.MustParse("v1.2.3"),
+			expected: semver.MustParse("v1.2.4"),
+			changelog: changelog.Changelog{
+				Changes: []changelog.Entry{
+					{Type: changelog.TypeBreaking},
+				},
+			},
+			entryCap: bump.Patch,
+		},
+		{
+			name:     "Major_change_limit_to_minor",
+			current:  semver.MustParse("v1.2.3"),
+			expected: semver.MustParse("v1.3.0"),
+			changelog: changelog.Changelog{
+				Changes: []changelog.Entry{
+					{Type: changelog.TypeBreaking},
+				},
+			},
+			entryCap: bump.Minor,
+		},
+	}
+
+	depsOnlyCases := []testCaseWithCap{
+		{
+			name:     "Minor_dep_limited_to_patch",
+			current:  semver.MustParse("v1.2.3"),
+			expected: semver.MustParse("v1.2.4"),
+			changelog: changelog.Changelog{
+				Dependencies: []changelog.Dependency{
+					{From: semver.MustParse("v9.9.9"), To: semver.MustParse("v9.10.9")},
+				},
+			},
+			dependencyCap: bump.Patch,
+		},
+		{
+			name:     "Major_dep_limited_to_patch",
+			current:  semver.MustParse("v1.2.3"),
+			expected: semver.MustParse("v1.2.4"),
+			changelog: changelog.Changelog{
+				Dependencies: []changelog.Dependency{
+					{From: semver.MustParse("v9.9.9"), To: semver.MustParse("v10.0.0")},
+				},
+			},
+			dependencyCap: bump.Patch,
+		},
+		{
+			name:     "Major_dep_limited_to_minor",
+			current:  semver.MustParse("v1.2.3"),
+			expected: semver.MustParse("v1.3.0"),
+			changelog: changelog.Changelog{
+				Dependencies: []changelog.Dependency{
+					{From: semver.MustParse("v9.9.9"), To: semver.MustParse("v10.0.0")},
+				},
+			},
+			dependencyCap: bump.Minor,
+		},
+	}
+
+	mixedCases := []testCaseWithCap{
+		{
+			name:     "Breaking_change_limited_to_patch_and_major_dep_limited_to_minor",
+			current:  semver.MustParse("v1.2.3"),
+			expected: semver.MustParse("v1.3.0"),
+			changelog: changelog.Changelog{
+				Changes: []changelog.Entry{
+					{Type: changelog.TypeBreaking},
+				},
+				Dependencies: []changelog.Dependency{
+					{From: semver.MustParse("v9.9.9"), To: semver.MustParse("v10.0.0")},
+				},
+			},
+			entryCap:      bump.Patch,
+			dependencyCap: bump.Minor,
+		}, {
+			name:     "Breaking_change_limited_to_minor_and_major_dep_limited_to_patch",
+			current:  semver.MustParse("v1.2.3"),
+			expected: semver.MustParse("v1.3.0"),
+			changelog: changelog.Changelog{
+				Changes: []changelog.Entry{
+					{Type: changelog.TypeBreaking},
+				},
+				Dependencies: []changelog.Dependency{
+					{From: semver.MustParse("v9.9.9"), To: semver.MustParse("v10.0.0")},
+				},
+			},
+			entryCap:      bump.Minor,
+			dependencyCap: bump.Patch,
+		},
+	}
+
+	testCases := []testCaseWithCap{}
+	testCases = append(testCases, changesOnlyCases...)
+	testCases = append(testCases, depsOnlyCases...)
+	testCases = append(testCases, mixedCases...)
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bumper := bumper.New(
+				tc.changelog,
+				bumper.WithEntryCap(tc.entryCap),
+				bumper.WithDependencyCap(tc.dependencyCap),
+			)
 			next, err := bumper.Bump(tc.current)
 			if err != nil {
 				t.Fatalf("Bumping version: %v", err)

--- a/src/bumper/bumper_test.go
+++ b/src/bumper/bumper_test.go
@@ -26,10 +26,12 @@ type testCaseWithCap struct {
 	dependencyCap bump.Type
 }
 
-func TestBumper_Bump_changesOnlyCases(t *testing.T) {
+//nolint:funlen
+func TestBumper_Bump(t *testing.T) {
 	t.Parallel()
 
 	testCases := []testCase{
+		// Test cases that involve only changes
 		{
 			name:     "Patch_On_Bugfixes_Only",
 			current:  semver.MustParse("v1.2.3"),
@@ -61,30 +63,8 @@ func TestBumper_Bump_changesOnlyCases(t *testing.T) {
 				},
 			},
 		},
-	}
 
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			bumper := bumper.New(tc.changelog)
-			next, err := bumper.Bump(tc.current)
-			if err != nil {
-				t.Fatalf("Bumping version: %v", err)
-			}
-
-			if !tc.expected.Equal(next) {
-				t.Fatalf("Expected %v, got %v", tc.expected, next)
-			}
-		})
-	}
-}
-
-func TestBumper_Bump_depsOnlyCases(t *testing.T) {
-	t.Parallel()
-
-	testCases := []testCase{
+		// Test cases that involve only dependencies
 		{
 			name:     "Patch_On_Deps_Patch",
 			current:  semver.MustParse("v1.2.3"),
@@ -115,30 +95,8 @@ func TestBumper_Bump_depsOnlyCases(t *testing.T) {
 				},
 			},
 		},
-	}
 
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			bumper := bumper.New(tc.changelog)
-			next, err := bumper.Bump(tc.current)
-			if err != nil {
-				t.Fatalf("Bumping version: %v", err)
-			}
-
-			if !tc.expected.Equal(next) {
-				t.Fatalf("Expected %v, got %v", tc.expected, next)
-			}
-		})
-	}
-}
-
-func TestBumper_Bump_mixedCases(t *testing.T) {
-	t.Parallel()
-
-	testCases := []testCase{
+		// Mixed test cases
 		{
 			name:     "Enhancement_and_Patch_On_Deps_Minor",
 			current:  semver.MustParse("v1.2.3"),
@@ -186,10 +144,12 @@ func TestBumper_Bump_mixedCases(t *testing.T) {
 	}
 }
 
-func TestBumper_BumpWithCap_changesOnlyCases(t *testing.T) {
+//nolint:funlen
+func TestBumper_BumpWithCap(t *testing.T) {
 	t.Parallel()
 
 	testCases := []testCaseWithCap{
+		// Test cases that involve only changes
 		{
 			name:     "Minor_Change_limit_to_patch",
 			current:  semver.MustParse("v1.2.3"),
@@ -224,33 +184,8 @@ func TestBumper_BumpWithCap_changesOnlyCases(t *testing.T) {
 			},
 			entryCap: bump.Minor,
 		},
-	}
 
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			bumper := bumper.New(tc.changelog)
-			bumper.EntryCap = tc.entryCap
-			bumper.DependencyCap = tc.dependencyCap
-
-			next, err := bumper.Bump(tc.current)
-			if err != nil {
-				t.Fatalf("Bumping version: %v", err)
-			}
-
-			if !tc.expected.Equal(next) {
-				t.Fatalf("Expected %v, got %v", tc.expected, next)
-			}
-		})
-	}
-}
-
-func TestBumper_BumpWithCap_depsOnlyCases(t *testing.T) {
-	t.Parallel()
-
-	testCases := []testCaseWithCap{
+		// Test cases that involve only dependencies
 		{
 			name:     "Minor_dep_limited_to_patch",
 			current:  semver.MustParse("v1.2.3"),
@@ -284,33 +219,8 @@ func TestBumper_BumpWithCap_depsOnlyCases(t *testing.T) {
 			},
 			dependencyCap: bump.Minor,
 		},
-	}
 
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			bumper := bumper.New(tc.changelog)
-			bumper.EntryCap = tc.entryCap
-			bumper.DependencyCap = tc.dependencyCap
-
-			next, err := bumper.Bump(tc.current)
-			if err != nil {
-				t.Fatalf("Bumping version: %v", err)
-			}
-
-			if !tc.expected.Equal(next) {
-				t.Fatalf("Expected %v, got %v", tc.expected, next)
-			}
-		})
-	}
-}
-
-func TestBumper_BumpWithCap_mixedCases(t *testing.T) {
-	t.Parallel()
-
-	testCases := []testCaseWithCap{
+		// Mixed test cases
 		{
 			name:     "Breaking_change_limited_to_patch_and_major_dep_limited_to_minor",
 			current:  semver.MustParse("v1.2.3"),
@@ -325,7 +235,8 @@ func TestBumper_BumpWithCap_mixedCases(t *testing.T) {
 			},
 			entryCap:      bump.Patch,
 			dependencyCap: bump.Minor,
-		}, {
+		},
+		{
 			name:     "Breaking_change_limited_to_minor_and_major_dep_limited_to_patch",
 			current:  semver.MustParse("v1.2.3"),
 			expected: semver.MustParse("v1.3.0"),

--- a/src/bumper/bumper_test.go
+++ b/src/bumper/bumper_test.go
@@ -231,11 +231,10 @@ func TestBumper_BumpWithCap_changesOnlyCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			bumper := bumper.New(
-				tc.changelog,
-				bumper.WithEntryCap(tc.entryCap),
-				bumper.WithDependencyCap(tc.dependencyCap),
-			)
+			bumper := bumper.New(tc.changelog)
+			bumper.EntryCap = tc.entryCap
+			bumper.DependencyCap = tc.dependencyCap
+
 			next, err := bumper.Bump(tc.current)
 			if err != nil {
 				t.Fatalf("Bumping version: %v", err)
@@ -292,11 +291,10 @@ func TestBumper_BumpWithCap_depsOnlyCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			bumper := bumper.New(
-				tc.changelog,
-				bumper.WithEntryCap(tc.entryCap),
-				bumper.WithDependencyCap(tc.dependencyCap),
-			)
+			bumper := bumper.New(tc.changelog)
+			bumper.EntryCap = tc.entryCap
+			bumper.DependencyCap = tc.dependencyCap
+
 			next, err := bumper.Bump(tc.current)
 			if err != nil {
 				t.Fatalf("Bumping version: %v", err)
@@ -349,11 +347,10 @@ func TestBumper_BumpWithCap_mixedCases(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			bumper := bumper.New(
-				tc.changelog,
-				bumper.WithEntryCap(tc.entryCap),
-				bumper.WithDependencyCap(tc.dependencyCap),
-			)
+			bumper := bumper.New(tc.changelog)
+			bumper.EntryCap = tc.entryCap
+			bumper.DependencyCap = tc.dependencyCap
+
 			next, err := bumper.Bump(tc.current)
 			if err != nil {
 				t.Fatalf("Bumping version: %v", err)


### PR DESCRIPTION
Right now, a major bump in a dependency will result in a major bump performed by `next-version`. There is a mechanism implemented to prevent this from happening:

https://github.com/newrelic/release-toolkit/blob/7402f581e2c56cec1d4db50c88b24ddfb347f089/src/bumper/bumper.go#L20

This PR should expose this behavior. Solves #115

## Additional notes for the reviewer:

I saw that there was an issue in the bumper that was capping the dependency version using the value from the entry cap, resulting in the dependency cap being ignored. Not only I fixed it but I also added tests as that option was not being tested at all.