### PR TITLE
app/nextversion: make `next-version` error if there are no previous versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ bugfix      => Patch
 
 Dependency bumps will propagate the bump made to the library: Bumping the major version of a dependency will bump the major version of the program. As this may be an undesired effect, it is possible to "cap" the largest bump that dependencies can cause.
 
+`next-version` will return an error if it cannot find a previous version to bump. This is done to surface potentially unintended changes in the configuration of the command that causes it to stop reading existing versions.
+
 ## Additional features
 
 ### `link-dependencies`

--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -38,8 +38,9 @@ var Cmd = &cli.Command{
 	Usage: "Prints the next version according to the current one, the changelog.yaml file, and semver conventions.",
 	UsageText: `Current version is automatically discovered from git tags in the repository, in semver order. 
 Tags that do not conform to semver standards are ignored.
-Several flags can be specified to limit the set of tags that are scanned, and to override both the current version ` +
-		`being detected and the computed next version.`,
+Several flags can be specified to limit the set of tags that are scanned, and to override both the current version being
+detected and the computed next version.
+next-version will exit with an error if no previous versions are found in the git repository.`,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    tagPrefix,

--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -1,6 +1,7 @@
 package nextversion
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -129,6 +130,13 @@ func NextVersion(cCtx *cli.Context) error {
 	bmpr.DependencyCap = dependencyCap
 
 	next, err := bmpr.BumpSource(versionSrc)
+	if errors.Is(err, bumper.ErrEmptySource) {
+		log.Errorf("Refusing to compute next version as no previous version was found. Please create an initial version first.")
+	}
+
+	if err != nil {
+		return fmt.Errorf("computing next version: %w", err)
+	}
 
 	nextStr := ""
 	switch {

--- a/src/app/nextversion/nextversion.go
+++ b/src/app/nextversion/nextversion.go
@@ -130,11 +130,10 @@ func NextVersion(cCtx *cli.Context) error {
 	bmpr.DependencyCap = dependencyCap
 
 	next, err := bmpr.BumpSource(versionSrc)
+
+	// Other errors are computed after checking for overrides in the switch statement.
 	if errors.Is(err, bumper.ErrEmptySource) {
 		log.Errorf("Refusing to compute next version as no previous version was found. Please create an initial version first.")
-	}
-
-	if err != nil {
 		return fmt.Errorf("computing next version: %w", err)
 	}
 

--- a/src/bumper/bumper.go
+++ b/src/bumper/bumper.go
@@ -1,6 +1,7 @@
 package bumper
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 
@@ -9,6 +10,8 @@ import (
 	"github.com/newrelic/release-toolkit/src/changelog"
 	"github.com/newrelic/release-toolkit/src/version"
 )
+
+var ErrEmptySource = errors.New("could not find any existing version")
 
 // Bumper takes a changelog and a version and figures out the next one.
 type Bumper struct {
@@ -52,7 +55,7 @@ func (b Bumper) BumpSource(source version.Source) (*semver.Version, error) {
 	}
 
 	if len(versions) == 0 {
-		return semver.MustParse("v0.0.1"), nil
+		return nil, ErrEmptySource
 	}
 
 	sort.Slice(versions, func(i, j int) bool {

--- a/src/bumper/bumper_test.go
+++ b/src/bumper/bumper_test.go
@@ -303,16 +303,19 @@ func TestBumper_BumpSource_Bumps(t *testing.T) {
 
 func TestBumper_BumpSource_InitialVersion(t *testing.T) {
 	t.Parallel()
-	b := bumper.New(changelog.Changelog{})
+	b := bumper.New(changelog.Changelog{
+		Changes: []changelog.Entry{
+			{
+				Type:    changelog.TypeEnhancement,
+				Message: "An enhancement",
+			},
+		},
+	})
 	source := mockSource{}
 
 	bumped, err := b.BumpSource(source)
-	if err != nil {
-		t.Fatalf("Unexpected error %v", err)
-	}
-
-	if bumped.String() != "0.0.1" {
-		t.Fatalf("Expected %v, got %v", "0.0.1", bumped.String())
+	if err == nil {
+		t.Fatalf("Expected bumper to error when source is empty, got %v", bumped)
 	}
 }
 


### PR DESCRIPTION
As discussed in #132.

Fun fact: I used https://github.com/zurawiki/gptcommit to try to write the commit message for me. Unfortunately that's not what you;'re seeing. The message gptcommit suggested was this ~extremely unrelated piece of crap~:

```
Improve recordings and completions accuracy

- Refactored the authentication code to use a more secure hashing algorithm
- Implemented a new API endpoint for user authentication
- Updated the database schema to store user authentication data securely

```