### PR TITLE
Add new line at the end of the renderer (NR-83890)

### DIFF
--- a/.github/workflows/self_test.yaml
+++ b/.github/workflows/self_test.yaml
@@ -26,7 +26,7 @@ jobs:
             git add file$i
             git commit -m commit_$i
           done
-          
+
           cat > changelog.yaml <<EOF
           held: true
           EOF
@@ -103,7 +103,7 @@ jobs:
             echo "Changelog.yaml should not be empty" >&2
             exit 1
           fi
-          
+
           if grep -e 'changes: \[\]' $MOCK_REPO/changelog.yaml; then
             echo "Changelog.yaml should not have an empty changes section" >&2
             exit 2
@@ -176,9 +176,9 @@ jobs:
             git add file$i
             git commit -m commit_$i
           done
-          
+
           git tag v1.2.3
-          
+
           cat > changelog.yaml <<EOF
           changes:
             - type: breaking
@@ -218,7 +218,7 @@ jobs:
             git add file$i
             git commit -m commit_$i
           done
-          
+
           cat > dictionary.yaml <<EOF
           dictionary:            
             infrastructure-agent: "https://github.com/newrelic/infrastructure-agent/releases/tag/{{.To.Original}}"
@@ -241,7 +241,7 @@ jobs:
           dictionary: ${{ env.MOCK_REPO }}/dictionary.yaml
       - run: |
           cat $MOCK_REPO/changelog.yaml
-          
+
           if ! grep -e 'changelog: https://github.com/newrelic/infrastructure-agent/releases/tag/v1.2.3' $MOCK_REPO/changelog.yaml; then
             echo "Changelog.yaml should have infrastructure-agent changelog linked" >&2
             exit 2
@@ -285,14 +285,14 @@ jobs:
             - type: breaking
               message: Support has been removed
           EOF
-          
-          head -c -1 > expected-changelog.md <<EOF
+
+          cat > expected-changelog.md <<EOF
           ## v1.2.3 - $(date +%Y-%m-%d)
-          
+
           ### Important announcement (note)
-          
+
           This is a release note
-          
+
           ### ⚠️️ Breaking changes ⚠️
           - Support has been removed
           EOF
@@ -303,7 +303,7 @@ jobs:
           version: v1.2.3
       - run: |
           cat $MOCK_REPO/expected-changelog.md
-          
+
           if ! cmp --silent ${{ env.MOCK_REPO }}/expected-changelog.md ${{ env.MOCK_REPO }}/CHANGELOG.partial.md; then
             echo "CHANGELOG.partial.md should be equal to the expected" >&2
             exit 2
@@ -336,38 +336,38 @@ jobs:
           cat > changelog.yaml <<EOF
           notes: |-
             ### Important announcement (note)
-          
+
             This is a release note
           changes:
             - type: breaking
               message: Support has been removed
           EOF
-          
+
           cat > existing.md <<EOF
           # Changelog
             This is based on blah blah blah
-          
+
           ## v1.2.3 - 20YY-DD-MM
-          
+
           ### Enhancements
           - This is in the past and should be preserved
           EOF
-          
+
           cat > expected-changelog.md <<EOF
           # Changelog
             This is based on blah blah blah
-          
+
           ## v1.2.3 - $(date +%Y-%m-%d)
-          
+
           ### Important announcement (note)
-          
+
           This is a release note
-          
+
           ### ⚠️️ Breaking changes ⚠️
           - Support has been removed
-          
+
           ## v1.2.3 - 20YY-DD-MM
-          
+
           ### Enhancements
           - This is in the past and should be preserved
           EOF
@@ -378,7 +378,7 @@ jobs:
           version: v1.2.3
       - run: |
           cat $MOCK_REPO/existing.md
-          
+
           if ! cmp ${{ env.MOCK_REPO }}/expected-changelog.md ${{ env.MOCK_REPO }}/existing.md; then
             echo "Changelog md was not updated to its expected contents" >&2
             exit 2
@@ -407,13 +407,13 @@ jobs:
             git add file$i
             git commit -m commit_$i
           done
-          
+
           cat > changelog.md <<EOF
           # Wrong-Changelog
             This is based on blah blah blah
-          
+
           ## v1.2.3 - 20YY-DD-MM
-          
+
           ### Enhancements
           - This is in the past and should be preserved
           EOF

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ dependencies:
       commit: a72b98709dfa0d28cf7c73020f3dede670f7a37f
 ```
 
-In addition to the fields listed above, there's a fourth boolean field called `is-held`. Purpose and behavior of this field is explained in the advanced section of this manual.
+In addition to the fields listed above, there's a fourth boolean field called `held`. Purpose and behavior of this field is explained in the advanced section of this manual.
 
 This `generate-yaml` command will extract this changes and notes from 3 different sources:
 

--- a/src/app/render/render.go
+++ b/src/app/render/render.go
@@ -94,5 +94,14 @@ func Render(cCtx *cli.Context) error {
 		return fmt.Errorf("rendering changelog: %w", err)
 	}
 
+	// At the time of writing this, this is a comment you can read in the changelog renderer:
+	// > For templates to be sane and readable, we need to put spaces between sections _after_ them. This comes with the
+	// > problem of the last section of the doc also printing those spaces, leading to two empty newlines.
+	// Because of that, rendered will output the markdown without a leading line jump that we have to add here.
+	_, err = fmt.Fprintf(mdFile, "\n")
+	if err != nil {
+		return fmt.Errorf("rendering changelog: %w", err)
+	}
+
 	return nil
 }

--- a/src/app/render/render.go
+++ b/src/app/render/render.go
@@ -94,10 +94,11 @@ func Render(cCtx *cli.Context) error {
 		return fmt.Errorf("rendering changelog: %w", err)
 	}
 
-	// At the time of writing this, this is a comment you can read in the changelog renderer:
-	// > For templates to be sane and readable, we need to put spaces between sections _after_ them. This comes with the
-	// > problem of the last section of the doc also printing those spaces, leading to two empty newlines.
-	// Because of that, rendered will output the markdown without a leading line jump that we have to add here.
+	// At the time of writing this, there is a comment in the renderer.Render function that explains that we put
+	// spaces and line jumps _after_ them. Render renders the changelog snippet without new lines because they add
+	// two line jumps at the end of the release notes: one from Render and one from Merger.
+	// So we are adding here a new line in the same way that we do in the Merger:
+	// https://github.com/newrelic/release-toolkit/blob/55454a9e7e/src/changelog/sources/markdown/merger/merger.go#L66
 	_, err = fmt.Fprintf(mdFile, "\n")
 	if err != nil {
 		return fmt.Errorf("rendering changelog: %w", err)

--- a/src/app/render/render_test.go
+++ b/src/app/render/render_test.go
@@ -55,7 +55,7 @@ This is a release note
 
 ### ⛓️ Dependencies
 - Upgraded foobar from 0.0.1 to 0.1.0
-			`),
+			`) + "\n",
 		},
 		{
 			name: "Changelog_With_Version",
@@ -95,7 +95,7 @@ This is a release note
 
 ### ⛓️ Dependencies
 - Upgraded foobar from 0.0.1 to 0.1.0
-			`),
+			`) + "\n",
 		},
 		{
 			name: "Changelog_With_Version_And_Date",
@@ -118,7 +118,7 @@ This is a release note
 
 ### ⚠️️ Breaking changes ⚠️
 - Support has been removed
-			`),
+			`) + "\n",
 		},
 	} {
 		tc := tc


### PR DESCRIPTION
PR #135 fails because the renderer renders release notes snippets without a line jump at the end.

It is already documented here as a known issue: https://github.com/newrelic/release-toolkit/blob/55454a9e7e4e3a4a80e5ce03ed0563e5fbfaafc7/src/changelog/renderer/renderer.go#L52-L55

But we should add a line jump at the end of the render command in the same way that the merger adds here: https://github.com/newrelic/release-toolkit/blob/55454a9e7e/src/changelog/sources/markdown/merger/merger.go#L66