### PR TITLE
renovate: match both `update` and `Update` in commit messages

### DIFF
--- a/src/changelog/sources/renovate/source.go
+++ b/src/changelog/sources/renovate/source.go
@@ -83,7 +83,7 @@ func (r Source) Changelog() (*changelog.Changelog, error) {
 }
 
 var (
-	renovateRegex = regexp.MustCompile(`update (.+)`)
+	renovateRegex = regexp.MustCompile(`[Uu]pdate (.+)`)
 	prRegex       = regexp.MustCompile(`(.+) \([#!](\d+)\)$`)
 	versionRegex  = regexp.MustCompile(`(.+) to (v?\d\S*)`)
 )


### PR DESCRIPTION
When run with conventional commits disabled, renovate message will start with `Update: ...` rather than `chore(deps): update...`, which was causing the existing regex to not match.

A test should be added for this, but I deliberately left that out to avoid clashing with an ongoing refactor of renovate tests.