### PR TITLE
NR-94443: add is-empty action in the ohi-release-notes action

### DIFF
--- a/contrib/ohi-release-notes/action.yml
+++ b/contrib/ohi-release-notes/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: ''
 outputs:
   is-empty:
-    description: "Outputs if there is no new release to be done"
+    description: "Outputs if changelog is empty"
     value: ${{ steps.empty.outputs.is-empty }}
   is-held:
     description: "Outputs if changelog is held"

--- a/contrib/ohi-release-notes/action.yml
+++ b/contrib/ohi-release-notes/action.yml
@@ -7,9 +7,6 @@ inputs:
   excluded-dirs:
     description: Exclude commits whose changes only impact files in specified dirs relative to repository root. Defaults to ".github".
     default: '.github'
-  fail-if-empty:
-    description: Fail if the empty toggle is active. Defaults to `true`.
-    default: 'true'
   fail-if-held:
     description: Fail if the held toggle is active. Defaults to `true`.
     default: 'true'
@@ -23,6 +20,9 @@ outputs:
   is-held:
     description: "Outputs if changelog is held"
     value: ${{ steps.held.outputs.is-held }}
+  skip-release:
+    description: "Outputs if a release should be skipped"
+    value: ${{ steps.check-release.outputs.skip }}
   next-version:
     description: "Version of this release"
     value: ${{ steps.version.outputs.next-version }}
@@ -54,53 +54,45 @@ runs:
       uses: newrelic/release-toolkit/is-empty@v1
       with:
         yaml: ${{ inputs.git-root }}/changelog.yaml
-    - name: Abort releasing if the changelog is empty
-      if: ${{ steps.empty.outputs.is-empty == 'true' && inputs.fail-if-empty == 'true' }}
-      shell: bash
-      run: |
-        echo "Aborting release, changelog is empty is-empty=${{ steps.empty.outputs.is-empty }}"
-        exit 0
     - name: Check if the release is held
-      if: ${{ steps.empty.outputs.is-empty != 'true' }}
       id: held
       uses: newrelic/release-toolkit/is-held@v1
       with:
         yaml: ${{ inputs.git-root }}/changelog.yaml
-    - name: Abort releasing if the release is held
-      if: ${{ steps.held.outputs.is-held == 'true' && inputs.fail-if-held == 'true' && steps.empty.outputs.is-empty != 'true' }}
+    - name: Check if the release should be skipped
+      id: check-release
       shell: bash
       run: |
-        echo "Release is being held, is-held=${{ steps.held.outputs.is-held }}"
-        exit 0
+        echo "::set-output name=skip::${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}"
     - name: Link dependencies
-      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
+      if: ${{ steps.check-release.outputs.skip != 'true' }}
       uses: newrelic/release-toolkit/link-dependencies@v1
       with:
         dictionary: ${{ inputs.link-dependencies-dictionary }}
         yaml: ${{ inputs.git-root }}/changelog.yaml
     - name: Calculate next version
-      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
+      if: ${{ steps.check-release.outputs.skip != 'true' }}
       id: version
       uses: newrelic/release-toolkit/next-version@v1
       with:
         git-root: ${{ inputs.git-root }}
         yaml: ${{ inputs.git-root }}/changelog.yaml
     - name: Update the markdown
-      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
+      if: ${{ steps.check-release.outputs.skip != 'true' }}
       uses: newrelic/release-toolkit/update-markdown@v1
       with:
         markdown: ${{ inputs.git-root }}/CHANGELOG.md
         yaml: ${{ inputs.git-root }}/changelog.yaml
         version: ${{ steps.version.outputs.next-version }}
     - name: Render the changelog snippet
-      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
+      if: ${{ steps.check-release.outputs.skip != 'true' }}
       uses: newrelic/release-toolkit/render@v1
       with:
         markdown: ${{ inputs.git-root }}/CHANGELOG.partial.md
         yaml: ${{ inputs.git-root }}/changelog.yaml
         version: ${{ steps.version.outputs.next-version }}
     - name: Create outputs
-      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
+      if: ${{ steps.check-release.outputs.skip != 'true' }}
       shell: bash
       id: release
       run: |
@@ -114,7 +106,7 @@ runs:
         cat ${{ inputs.git-root }}/CHANGELOG.md  >> $GITHUB_OUTPUT
         echo "EOF"                               >> $GITHUB_OUTPUT
     - name: Clean the workspace
-      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
+      if: ${{ steps.check-release.outputs.skip != 'true' }}
       shell: bash
       run: |
         rm ${{ inputs.git-root }}/CHANGELOG.md.bak

--- a/contrib/ohi-release-notes/action.yml
+++ b/contrib/ohi-release-notes/action.yml
@@ -7,6 +7,9 @@ inputs:
   excluded-dirs:
     description: Exclude commits whose changes only impact files in specified dirs relative to repository root. Defaults to ".github".
     default: '.github'
+  fail-if-empty:
+    description: Fail if the empty toggle is active. Defaults to `true`.
+    default: 'true'
   fail-if-held:
     description: Fail if the held toggle is active. Defaults to `true`.
     default: 'true'
@@ -14,6 +17,12 @@ inputs:
     description: Sets the link dependency dictionary.
     default: ''
 outputs:
+  is-empty:
+    description: "Outputs if there is no new release to be done"
+    value: ${{ steps.empty.outputs.is-empty }}
+  is-held:
+    description: "Outputs if changelog is held"
+    value: ${{ steps.held.outputs.is-held }}
   next-version:
     description: "Version of this release"
     value: ${{ steps.version.outputs.next-version }}
@@ -40,41 +49,58 @@ runs:
         git-root: ${{ inputs.git-root }}
         markdown: ${{ inputs.git-root }}/CHANGELOG.md
         yaml: ${{ inputs.git-root }}/changelog.yaml
+    - name: Check if the release is empty
+      id: empty
+      uses: newrelic/release-toolkit/is-empty@v1
+      with:
+        yaml: ${{ inputs.git-root }}/changelog.yaml
+    - name: Abort releasing if the changelog is empty
+      if: ${{ steps.empty.outputs.is-empty == 'true' && inputs.fail-if-empty == 'true' }}
+      shell: bash
+      run: |
+        echo "Aborting release, changelog is empty is-empty=${{ steps.empty.outputs.is-empty }}"
+        exit 0
     - name: Check if the release is held
+      if: ${{ steps.empty.outputs.is-empty != 'true' }}
       id: held
       uses: newrelic/release-toolkit/is-held@v1
       with:
         yaml: ${{ inputs.git-root }}/changelog.yaml
     - name: Abort releasing if the release is held
-      if: ${{ steps.held.outputs.is-held == 'true' && inputs.fail-if-held == 'true' }}
+      if: ${{ steps.held.outputs.is-held == 'true' && inputs.fail-if-held == 'true' && steps.empty.outputs.is-empty != 'true' }}
       shell: bash
       run: |
-        echo "Releases are being held. Aborting." >&2
-        exit 1
+        echo "Release is being held, is-held=${{ steps.held.outputs.is-held }}"
+        exit 0
     - name: Link dependencies
+      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
       uses: newrelic/release-toolkit/link-dependencies@v1
       with:
         dictionary: ${{ inputs.link-dependencies-dictionary }}
         yaml: ${{ inputs.git-root }}/changelog.yaml
     - name: Calculate next version
+      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
       id: version
       uses: newrelic/release-toolkit/next-version@v1
       with:
         git-root: ${{ inputs.git-root }}
         yaml: ${{ inputs.git-root }}/changelog.yaml
     - name: Update the markdown
+      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
       uses: newrelic/release-toolkit/update-markdown@v1
       with:
         markdown: ${{ inputs.git-root }}/CHANGELOG.md
         yaml: ${{ inputs.git-root }}/changelog.yaml
         version: ${{ steps.version.outputs.next-version }}
     - name: Render the changelog snippet
+      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
       uses: newrelic/release-toolkit/render@v1
       with:
         markdown: ${{ inputs.git-root }}/CHANGELOG.partial.md
         yaml: ${{ inputs.git-root }}/changelog.yaml
         version: ${{ steps.version.outputs.next-version }}
     - name: Create outputs
+      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
       shell: bash
       id: release
       run: |
@@ -88,6 +114,7 @@ runs:
         cat ${{ inputs.git-root }}/CHANGELOG.md  >> $GITHUB_OUTPUT
         echo "EOF"                               >> $GITHUB_OUTPUT
     - name: Clean the workspace
+      if: ${{ steps.empty.outputs.is-empty != 'true' && steps.held.outputs.is-held != 'true' }}
       shell: bash
       run: |
         rm ${{ inputs.git-root }}/CHANGELOG.md.bak

--- a/contrib/ohi-release-notes/run.sh
+++ b/contrib/ohi-release-notes/run.sh
@@ -64,7 +64,6 @@ EOM
 
 # parsing flags
 EXCLUDED_DIRECTORIES=".github"
-IS_EMPTY_FAIL="--fail"
 IS_HELD_FAIL="--fail"
 DICTIONARY=".github/rt-dictionary.yaml"
 GIT_ROOT="."
@@ -106,7 +105,7 @@ fi
 
     # generating the changelog
     ${RT_BIN} generate-yaml --excluded-dirs "$EXCLUDED_DIRECTORIES"
-    ${RT_BIN} is-empty "${IS_EMPTY_FAIL}" > /dev/null
+    ${RT_BIN} is-empty > /dev/null
     ${RT_BIN} is-held "${IS_HELD_FAIL}" > /dev/null
     if [ -f "$DICTIONARY" ]; then
         ${RT_BIN} link-dependencies --dictionary "$DICTIONARY"

--- a/contrib/ohi-release-notes/run.sh
+++ b/contrib/ohi-release-notes/run.sh
@@ -38,6 +38,7 @@ DESCRIPTION:
    Wrapper for release toolkit that runs commands needed to create the release notes for an OHI:
     * rt validate-markdown
     * rt generate-yaml
+    * rt is-empty
     * rt is-held
     * rt link-dependencies
     * rt update-markdown (with the version calculated from the next-version command)
@@ -63,6 +64,7 @@ EOM
 
 # parsing flags
 EXCLUDED_DIRECTORIES=".github"
+IS_EMPTY_FAIL="--fail"
 IS_HELD_FAIL="--fail"
 DICTIONARY=".github/rt-dictionary.yaml"
 GIT_ROOT="."
@@ -104,7 +106,8 @@ fi
 
     # generating the changelog
     ${RT_BIN} generate-yaml --excluded-dirs "$EXCLUDED_DIRECTORIES"
-    ${RT_BIN} is-held ${IS_HELD_FAIL} > /dev/null
+    ${RT_BIN} is-empty "${IS_EMPTY_FAIL}" > /dev/null
+    ${RT_BIN} is-held "${IS_HELD_FAIL}" > /dev/null
     if [ -f "$DICTIONARY" ]; then
         ${RT_BIN} link-dependencies --dictionary "$DICTIONARY"
     else

--- a/src/app/generate/generate_test.go
+++ b/src/app/generate/generate_test.go
@@ -377,7 +377,7 @@ func repoWithCommits(t *testing.T, author string, commits ...string) string {
 		cmd.Stderr = &out
 		if err := cmd.Run(); err != nil {
 			t.Errorf("%s output:\n%s", cmdline, out.String())
-			t.Fatalf("Error bootstraping test git repo: %v", err)
+			t.Fatalf("Error bootstrapping test git repo: %v", err)
 		}
 	}
 

--- a/src/app/nextversion/nextversion_test.go
+++ b/src/app/nextversion/nextversion_test.go
@@ -560,7 +560,7 @@ func repoWithTags(t *testing.T, tags ...string) string {
 		cmd.Stderr = &out
 		if err := cmd.Run(); err != nil {
 			t.Errorf("%s output:\n%s", cmdline, out.String())
-			t.Fatalf("Error bootstraping test git repo: %v", err)
+			t.Fatalf("Error bootstrapping test git repo: %v", err)
 		}
 	}
 

--- a/src/git/commit_test.go
+++ b/src/git/commit_test.go
@@ -57,7 +57,7 @@ func repoWithCommitsAndTags(t *testing.T, commitsAndTags ...testCommitTag) strin
 		cmd.Stderr = &out
 		if err := cmd.Run(); err != nil {
 			t.Errorf("%s output:\n%s", cmdline, out.String())
-			t.Fatalf("Error bootstraping test git repo: %v", err)
+			t.Fatalf("Error bootstrapping test git repo: %v", err)
 		}
 	}
 

--- a/src/git/tag_source_test.go
+++ b/src/git/tag_source_test.go
@@ -49,7 +49,7 @@ func executeCMDs(t *testing.T, cmds []string, dir string) {
 		cmd.Stderr = &out
 		if err := cmd.Run(); err != nil {
 			t.Errorf("%s output:\n%s", cmdline, out.String())
-			t.Fatalf("Error bootstraping test git repo: %v", err)
+			t.Fatalf("Error bootstrapping test git repo: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
This PR adds the `is-empty` action and makes the `is-empty` and `is-held` actions fail gracefully.

This has been tested in a forked repository, you can check it in the following links:
- Changelog being empty: https://github.com/marcsanmi/nri-kafka/actions/runs/4414349494/jobs/7735939509
- Changelog being held: https://github.com/marcsanmi/nri-kafka/actions/runs/4414290292/jobs/7735801804
- Releasing properly when neither empty nor held are set: https://github.com/marcsanmi/nri-kafka/actions/runs/4414189743/jobs/7735720930