### PR TITLE
fix(ohi-release-notes): it should not fail if changelog is empty

### DIFF
--- a/contrib/ohi-release-notes/action.yml
+++ b/contrib/ohi-release-notes/action.yml
@@ -49,6 +49,7 @@ runs:
         git-root: ${{ inputs.git-root }}
         markdown: ${{ inputs.git-root }}/CHANGELOG.md
         yaml: ${{ inputs.git-root }}/changelog.yaml
+        exit-code: "0"
     - name: Check if the release is empty
       id: empty
       uses: newrelic/release-toolkit/is-empty@v1


### PR DESCRIPTION
Generate YAML should not fail if the changelog is empty

>   exit-code:
    description: Exit code if changelog is empty
    required: false
    default: “1”