### PR TITLE
Revert "revert tests!!"

### DIFF
--- a/contrib/ohi-release-notes/run.sh
+++ b/contrib/ohi-release-notes/run.sh
@@ -3,9 +3,7 @@
 set -euo pipefail
 
 RT_PKG="github.com/newrelic/release-toolkit@latest"
-# TODO this is just added to check the CI tests are passing and should be reverted before merge , chicken egg thing.
-# DICTIONARY_URL="https://raw.githubusercontent.com/newrelic/release-toolkit/v1/contrib/ohi-release-notes/rt-dictionary.yml"
-DICTIONARY_URL="https://raw.githubusercontent.com/newrelic/newrelic-infra-checkers/main/rt-dictionary/.rt-dictionary.yml"
+DICTIONARY_URL="https://raw.githubusercontent.com/newrelic/release-toolkit/v1/contrib/ohi-release-notes/rt-dictionary.yml"
 ARGS="$*"
 
 


### PR DESCRIPTION
This commit was used in order to test the command with the current self-test, v1 didn't have that file so I pointed to another file. 
Since #152 is merged and v1 points to the latest commit I'm pointing this to the right URL.
This reverts commit 6066c508cc0369b4b8271fb80a2eccb28bf80b1f.