### PR TITLE
Change back EXCLUDED_DEPENDENCIES_MANIFEST_URL

### DIFF
--- a/contrib/ohi-release-notes/run.sh
+++ b/contrib/ohi-release-notes/run.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 RT_PKG="github.com/newrelic/release-toolkit@latest"
 DICTIONARY_URL="https://raw.githubusercontent.com/newrelic/release-toolkit/v1/contrib/ohi-release-notes/rt-dictionary.yml"
-EXCLUDED_DEPENDENCIES_MANIFEST_URL="https://raw.githubusercontent.com/newrelic/release-toolkit/msanmiquel/exclude-dev-dependencies/contrib/ohi-release-notes/excluded-dependencies.yml"
+EXCLUDED_DEPENDENCIES_MANIFEST_URL="https://raw.githubusercontent.com/newrelic/release-toolkit/v1/contrib/ohi-release-notes/excluded-dependencies.yml"
 ARGS="$*"
 
 


### PR DESCRIPTION
Following https://github.com/newrelic/release-toolkit/pull/160 after updating the `v1` tag.