### PR TITLE
Add release-toolkit the hability to release itself (NR-233241)

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -47,7 +47,7 @@ jobs:
         run: GITHUB_ACTIONS=false go test -race ./...
 
   check-changelog:
-    name: Run tests
+    name: Check changelog
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -33,35 +33,34 @@ jobs:
           echo "${target_head} = ${merge_base}"
           exit 0
 
-  test:
+  go-test:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.19'
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: "go.mod"
       - name: Run tests
         # CLI autodetects whether it is running on GHA or not. If we let GHA set this to true, as it normally does,
         # tests cases where GITHUB_ACTIONS is expected to be unset would fail.
         run: GITHUB_ACTIONS=false go test -race ./...
+
+  check-changelog:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CHANGELOG is valid
+        uses: ./validate-markdown
 
   static-analysis:
     name: Static analysis and linting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.19'
+          go-version-file: "go.mod"
       - uses: newrelic/newrelic-infra-checkers@v1
         with:
           # Use full list of linters, rather than the (default) limited set.

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -50,6 +50,7 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Check if CHANGELOG is valid
         uses: ./validate-markdown
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,6 +86,8 @@ jobs:
         with:
           version: ${{ steps.version.outputs.next-version }}
       - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release create \
             ${{ steps.version.outputs.next-version }} \
@@ -100,14 +102,14 @@ jobs:
           git pull --tags
 
           # Delete, tag, and push the major tag
-          git push --delete origin "${{ steps.version.outputs.next-version-major }}"
-          git push tag "${{ steps.version.outputs.next-version-major }}" "${{ steps.version.outputs.next-version }}"
-          git push origin "${{ steps.version.outputs.next-version-major }}"
+          git push --delete origin "${{ steps.version.outputs.next-version-major }}" || true  # Do not fail if the tag does not exist. It will be created.
+          git tag --force "${{ steps.version.outputs.next-version-major }}" "${{ steps.version.outputs.next-version }}"  # The tag might be deleted upstream bit still exists locally
+          git push origin "${{ steps.version.outputs.next-version-major }}"  # Push only the new tag
 
           # Delete, tag, and push the major.minor tag
-          git push --delete origin "${{ steps.version.outputs.next-version-major-minor }}"
-          git push tag "${{ steps.version.outputs.next-version-major-minor }}" "${{ steps.version.outputs.next-version }}"
-          git push origin "${{ steps.version.outputs.next-version-major-minor }}"
+          git push --delete origin "${{ steps.version.outputs.next-version-major-minor }}" || true  # Do not fail if the tag does not exist. It will be created.
+          git tag --force "${{ steps.version.outputs.next-version-major-minor }}" "${{ steps.version.outputs.next-version }}"  # The tag might be deleted upstream bit still exists locally
+          git push origin "${{ steps.version.outputs.next-version-major-minor }}"  # Push only the new tag
 
   notify:
     name: Test if release is needed

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,7 +112,7 @@ jobs:
           git push origin "${{ steps.version.outputs.next-version-major-minor }}"  # Push only the new tag
 
   notify:
-    name: Test if release is needed
+    name: Notify if somthing went wrong
     runs-on: ubuntu-latest
     needs: [ test-release-needed, make-release ]
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,104 @@
+name: Release on merge to main
+on:
+  push:
+    branches:
+      - main
+
+env:
+  BOT_NAME: newrelic-coreint-bot
+  BOT_EMAIL: coreint-dev@newrelic.com
+
+permissions:
+  contents: write
+
+jobs:
+  test-release-needed:
+    name: Test if release is needed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # Validation and generation.
+      - name: Validate that the markdown is correct
+        uses: ./validate-markdown
+      - name: Generate YAML
+        uses: ./generate-yaml
+        with:
+          excluded-dirs: .github
+
+      # Check that a release is needed.
+      - name: Check if the release is empty
+        id: empty
+        uses: ./is-empty
+      - name: Check if the release is held
+        id: held
+        uses: ./is-held
+      - name: Output if the release should be skipped
+        id: output
+        shell: bash
+        run: |
+          echo "skip=${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}" >> $GITHUB_OUTPUT
+    outputs:
+      make-release: ${{ steps.output.outputs.skip }}
+
+  make-release:
+    name: Test if release is needed
+    runs-on: ubuntu-latest
+    needs: [ test-release-needed ]
+    if: ${{ needs.test-release-needed.outputs.make-release }}
+    steps:
+      - name: Generate YAML
+        uses: ./generate-yaml
+        with:
+          excluded-dirs: .github
+
+      # Put release toolkit to work.
+      - name: Link dependencies
+        uses: ./link-dependencies
+      - name: Calculate next version
+        id: version
+        uses: ./next-version
+
+      # Prepare to commit the Changelog.
+      - name: Configure Git
+        run: |
+          git config user.name '${{ env.BOT_NAME }}'
+          git config user.email '${{ env.BOT_EMAIL }}'
+
+      # Create changelog and commit it.
+      - name: Update the markdown
+        uses: ./update-markdown
+        with:
+          version: ${{ steps.version.outputs.next-version }}
+      - name: Commit updated changelog
+        run: |
+          git add CHANGELOG.md
+          git commit -m "Update changelog with changes from ${{ steps.version.outputs.next-version }}"
+          git push -u origin ${{ github.event.repository.default_branch }}
+
+      # Create the release from the commit above using only the changelog for this release.
+      - name: Render the changelog snippet
+        uses: ./render
+        with:
+          version: ${{ steps.version.outputs.next-version }}
+      - name: Create release
+        run: |
+          gh release create \
+            ${{ steps.version.outputs.next-version }} \
+            --title ${{ steps.version.outputs.next-version }} \
+            --target $(git rev-parse HEAD) \
+            --notes-file CHANGELOG.partial.md
+
+  notify:
+    name: Test if release is needed
+    runs-on: ubuntu-latest
+    needs: [ test-release-needed, make-release ]
+    steps:
+      - name: Notify failure via Slack
+        if: ${{ always() && failure() }}
+        uses: archive/github-actions-slack@master
+        with:
+          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
+          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+          slack-text: "❌ `${{ github.repository }}`: [release pipeline failed](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,7 @@ jobs:
             --target $(git rev-parse HEAD) \
             --notes-file CHANGELOG.partial.md
 
-      - name: Move major tag to this new commit
+      - name: Move major and major.minor tags to this new commit
         run: |
           # The release is created above, the repo still does not have the tag available here
           git fetch

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,14 +40,17 @@ jobs:
         run: |
           echo "skip=${{ steps.empty.outputs.is-empty == 'true' || steps.held.outputs.is-held == 'true' }}" >> $GITHUB_OUTPUT
     outputs:
-      make-release: ${{ steps.output.outputs.skip }}
+      make-release: ${{ steps.output.outputs.skip != true }}
 
   make-release:
-    name: Test if release is needed
+    name: Make the release if needed
     runs-on: ubuntu-latest
     needs: [ test-release-needed ]
     if: ${{ needs.test-release-needed.outputs.make-release }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Generate YAML
         uses: ./generate-yaml
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,6 +90,22 @@ jobs:
             --target $(git rev-parse HEAD) \
             --notes-file CHANGELOG.partial.md
 
+      - name: Move major tag to this new commit
+        run: |
+          # The release is created above, the repo still does not have the tag available here
+          git fetch
+          git pull --tags
+
+          # Delete, tag, and push the major tag
+          git push --delete origin "${{ steps.version.outputs.next-version-major }}"
+          git push tag "${{ steps.version.outputs.next-version-major }}" "${{ steps.version.outputs.next-version }}"
+          git push origin "${{ steps.version.outputs.next-version-major }}"
+
+          # Delete, tag, and push the major.minor tag
+          git push --delete origin "${{ steps.version.outputs.next-version-major-minor }}"
+          git push tag "${{ steps.version.outputs.next-version-major-minor }}" "${{ steps.version.outputs.next-version }}"
+          git push origin "${{ steps.version.outputs.next-version-major-minor }}"
+
   notify:
     name: Test if release is needed
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/CHANGELOG.md.bak
+/CHANGELOG.md.partial
+/changelog.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
+## Unreleased
+
 ## v1.0.0 - 2023-11-02
 
 ### 🚀 Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## v1.0.0 - 2023-11-02
+
+### 🚀 Enhancements
+- First release of release toolkit
+


### PR DESCRIPTION
This should test its own CHANGELOG.md and have a pipeline that release itself on merge to main.

I took the chance to update a few things on the pipeline. There was a cache mechanism that is not needed anymore with the new version of action/setup-golang

I left al dependencies without being updated on purpose because I would like to add renovatebot and configure its automerge on a future PR.

EDIT:

Now with #188 I tested this in a fork E2E. I change the upstream branc to fork's main so history in the fork is the same history as in this branch except the commit that the release toolkit creates.
 
![Screenshot 2024-04-04 at 17 54 50](https://github.com/newrelic/release-toolkit/assets/53659978/b343ba9f-cbee-46be-9ea0-7521282c1a69)

You can see tags being created correctly: https://github.com/newrelic-forks/release-toolkit/tags
And a new release: https://github.com/newrelic-forks/release-toolkit/releases/tag/v1.1.0

As a follow PR we can enable renovate to update automatically the repository and see that each PR being merged is going to be released correctly.
