### PR TITLE
fix: release token (NR-233241)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,9 +8,6 @@ env:
   BOT_NAME: newrelic-coreint-bot
   BOT_EMAIL: coreint-dev@newrelic.com
 
-permissions:
-  contents: write
-
 jobs:
   test-release-needed:
     name: Test if release is needed
@@ -51,6 +48,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: "${{ secrets.COREINT_BOT_TOKEN }}"
+      - name: Configure Git
+        run: |
+          git config user.name '${{ env.BOT_NAME }}'
+          git config user.email '${{ env.BOT_EMAIL }}'
+
       - name: Generate YAML
         uses: ./generate-yaml
         with:
@@ -62,12 +65,6 @@ jobs:
       - name: Calculate next version
         id: version
         uses: ./next-version
-
-      # Prepare to commit the Changelog.
-      - name: Configure Git
-        run: |
-          git config user.name '${{ env.BOT_NAME }}'
-          git config user.email '${{ env.BOT_EMAIL }}'
 
       # Create changelog and commit it.
       - name: Update the markdown
@@ -87,7 +84,7 @@ jobs:
           version: ${{ steps.version.outputs.next-version }}
       - name: Create release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.COREINT_BOT_TOKEN }}
         run: |
           gh release create \
             ${{ steps.version.outputs.next-version }} \


### PR DESCRIPTION
I tried to find a way so we can get rid of the BOT token because it seems to be a concern from the security team.

We cannot as GitHub does not have a proper way to give permissions to the token with a protected branch.

More info here: https://github.com/orgs/community/discussions/25305#discussioncomment-3247401

I removed the permission to the pipeline and used the token to fetch the repository and create the prerelease.