### PR TITLE
validator: check entry type through substring matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Unreleased section should follow [Release Toolkit](https://github.com/newrelic/release-toolkit#render-markdown-and-update-markdown)
 ## Unreleased
 
+### Enhancement
+- Fix markdown validator to match entry-type
+
 ## v1.1.0 - 2024-04-09
 
 ### ⛓️ Dependencies

--- a/src/changelog/sources/markdown/validator.go
+++ b/src/changelog/sources/markdown/validator.go
@@ -123,11 +123,19 @@ func (v *Validator) validateL2Children(l2doc *headingdoc.Doc) []error {
 
 // isEntryType detects if a L3 header is one of the defined changelog EntryTypes.
 func (v *Validator) isEntryType(header *headingdoc.Doc) bool {
-	return strings.ToLower(header.Name) == string(changelog.TypeEnhancement) ||
-		strings.ToLower(header.Name) == string(changelog.TypeBugfix) ||
-		strings.ToLower(header.Name) == string(changelog.TypeSecurity) ||
-		strings.ToLower(header.Name) == string(changelog.TypeBreaking) ||
-		strings.ToLower(header.Name) == string(changelog.TypeDependency)
+	for _, entryType := range []changelog.EntryType{
+		changelog.TypeBreaking,
+		changelog.TypeSecurity,
+		changelog.TypeEnhancement,
+		changelog.TypeBugfix,
+		changelog.TypeDependency,
+	} {
+		if strings.Contains(strings.ToLower(header.Name), strings.ToLower(string(entryType))) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ensureItemizedList ensures the body of a L3 header

--- a/src/changelog/sources/markdown/validator_test.go
+++ b/src/changelog/sources/markdown/validator_test.go
@@ -225,7 +225,7 @@ This is a release note
 			expected: []error{},
 		},
 		{
-			name: "Only enhancements",
+			name: "Only enhancements plural",
 			markdown: strings.TrimSpace(`
 # Changelog
 This is based on blah blah blah
@@ -233,6 +233,22 @@ This is based on blah blah blah
 ### Enhancements
 - Added this
 - Improved that
+
+## v1.2.3 - 2022-11-11
+
+### Enhancements
+- This is in the past and should not be included
+`),
+			expected: []error{},
+		},
+		{
+			name: "Only enhancement singular",
+			markdown: strings.TrimSpace(`
+# Changelog
+This is based on blah blah blah
+
+### Enhancement
+- Added this
 
 ## v1.2.3 - 2022-11-11
 

--- a/src/changelog/sources/markdown/validator_test.go
+++ b/src/changelog/sources/markdown/validator_test.go
@@ -224,6 +224,23 @@ This is a release note
 `),
 			expected: []error{},
 		},
+		{
+			name: "Only enhancements",
+			markdown: strings.TrimSpace(`
+# Changelog
+This is based on blah blah blah
+
+### Enhancements
+- Added this
+- Improved that
+
+## v1.2.3 - 2022-11-11
+
+### Enhancements
+- This is in the past and should not be included
+`),
+			expected: []error{},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Markdown validator tripped on me when using `Enhancements` (plural). As the `render` action outputs it in plural form, it only makes sense for the validator to also accept it in plural form.

Closes #130